### PR TITLE
[NOT READY] Import and reorganize account creation/filtering

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -1,0 +1,245 @@
+import difflib
+import itertools
+import math
+import os.path
+import re
+import subprocess
+import sys
+
+import ocflib.account.search as search
+import ocflib.account.utils as utils
+import ocflib.constants as constants
+import ocflib.misc.mail as mail
+import ocflib.validators as validators
+
+
+def create_home_dir(user):
+    """Create home directory for user. Makes a directory with appropriate
+    permissions, then copies in OCF's skeleton dotfiles."""
+
+    home = utils.home_dir(user['account_name'])
+    subprocess.check_call(
+        ['sudo', 'install', '-d', '--mode=0700', '--group=ocf',
+            '--owner=' + user, home],
+        stdout=sys.stderr)
+
+    for name in ['bashrc', 'bash_profile', 'bash_logout']:
+        path = os.path.join(os.path.dirname(__file__), 'rc', name)
+        subprocess.check_call(
+            ['sudo', 'install', '--mode=0600', '--group=ocf',
+                '--owner=' + user, path, os.path.join(home, '.' + name)],
+            stdout=sys.stderr)
+
+
+# TODO: is there a reason we make the user use makehttp, or should we just make
+# the public_html symlink at account creation?
+def create_web_dir(user):
+    """Create web directory for user with appropriate permissions. We start web
+    directories at 000; the user can later use makehttp to chmod them to
+    something readable by the webserver if they desire."""
+
+    path = utils.web_dir(user)
+    subprocess.check_call(
+        ['sudo', 'install', '-d', '--mode=0000', '--group=ocf',
+            '--owner=' + user, path],
+        stdout=sys.stderr)
+
+
+def send_created_mail(email, realname, username):
+    body = """Greetings from the Grotto of Hearst Gym,
+
+Your OCF account has been created and is ready for use! Welcome aboard!
+
+Your account name is: {username}
+
+As a brand-new OCF member, you're welcome to use any and all of our services.
+You can find out more about them on our wiki:
+
+https://ocf.io/wiki
+
+Keep in mind not to share your shiny new password with anyone, including OCF
+staffers. You can always reset it online:
+
+https://ocf.io/password
+
+Finally, we would like to remind you that the OCF is run entirely by student
+volunteers, and as such, we are always looking for new staff. If you value the
+services that the OCF provides to the UC Berkeley community and want to assist
+us in continuing to offer them, please visit:
+
+https://hello.ocf.berkeley.edu/
+
+If you have any other questions or problems, feel free to contact us by
+replying to this message.
+
+{signature}""".format(username=username,
+                      signature=constants.MAIL_SIGNATURE)
+
+    mail.send_mail(email, "[OCF] Your account has been created!", body)
+
+
+def send_rejected_mail(email, realname, username, reason):
+    body = """Greetings from the Grotto of Hearst Gym,
+
+Your OCF account, {username} has been rejected for the following reason:
+
+{reason}
+
+For information about account eligibility, see:
+
+https://wiki.ocf.berkeley.edu/membership/
+
+If you have any other questions or problems, feel free to contact us by
+replying to this message.
+
+{signature}""".format(username=username,
+                      reason=reason,
+                      signature=constants.MAIL_SIGNATURE)
+
+    mail.send_mail(email, "[OCF] Your account request has been rejected", body)
+
+
+class ValidationWarning(ValueError):
+    """Warning exception raised by validators when a staff member needs to
+    manually approve an account."""
+    pass
+
+
+class ValidationError(ValueError):
+    """Error exception raised by validators when a request should be
+    rejected."""
+    pass
+
+
+def validate_calnet_uid(uid):
+    """Verifies whether a given CalNet UID is eligible for a new OCF account.
+
+    Checks that:
+      - User doesn't already have an OCF account
+      - Affiliate type is eligible"""
+
+    # check for existing OCF accounts
+    existing_accounts = search.users_by_calnet_uid(uid)
+
+    if existing_accounts:
+        raise ValidationError(
+            "Calnet UID already has account: " + str(existing_accounts))
+
+    attrs = search.user_attrs_ucb(uid)
+
+    if not attrs:
+        raise ValidationError("CalNet UID can't be found in university LDAP.")
+
+    # check if user is eligible for an account
+    affiliations = attrs['berkeleyEduAffiliations']
+    if not eligible_for_account(affiliations):
+        raise ValidationError(
+            "Affiliate type not eligible for account: " + str(affiliations))
+
+
+def eligible_for_account(affiliations):
+    """Returns whether the list of affiliations makes one eligible for an
+    account."""
+
+    ALLOWED_AFFILIATES = [
+        'AFFILIATE-TYPE-CONSULTANT',
+        'AFFILIATE-TYPE-LBLOP STAFF',
+        'AFFILIATE-TYPE-VISITING SCHOLAR',
+        'AFFILIATE-TYPE-VOLUNTEER',
+        'AFFILIATE-TYPE-HHMI RESEARCHER',
+        'AFFILIATE-TYPE-VISITING STU RESEARCHER',
+        'AFFILIATE-TYPE-LBL/DOE POSTDOC',
+        'AFFILIATE-TYPE-TEMP AGENCY',
+        'AFFILIATE-TYPE-COMMITTEE MEMBER',
+        'AFFILIATE-TYPE-STAFF OF UC/OP/AFFILIATED ORGS',
+        'AFFILIATE-TYPE-CONTRACTOR',
+        'AFFILIATE-TYPE-CONCURR ENROLL']
+
+    if any(affiliation in ALLOWED_AFFILIATES for affiliation in affiliations) \
+            and 'AFFILIATE-STATUS-EXPIRED' not in affiliations:
+        return True
+
+    if ('EMPLOYEE-TYPE-ACADEMIC' in affiliations
+            or 'EMPLOYEE-TYPE-STAFF' in affiliations) \
+            and 'EMPLOYEE-STATUS-EXPIRED' not in affiliations:
+        return True
+
+    if 'STUDENT-TYPE-REGISTERED' in affiliations and \
+            'STUDENT-STATUS-EXPIRED' not in affiliations:
+        return True
+
+    return False
+
+
+def validate_username(username, realname):
+    """Validates a username and realname pair to ensure:
+
+    * Username isn't already in use
+    * Username is based on realname
+    * Username isn't restricted."""
+
+    if search.user_exists(username):
+        raise ValidationError("Username {} already exists.".format(username))
+
+    try:
+        validators.validate_username(username)
+    except ValueError as ex:
+        raise ValidationError(str(ex))
+
+    SIMILARITY_THRESHOLD = 1
+
+    if similarity_heuristic(realname, username) > SIMILARITY_THRESHOLD:
+        raise ValidationWarning(
+            "Username {} not based on real name {}".format(username, realname))
+
+    if any(word in username for word in constants.BAD_WORDS):
+        raise ValidationWarning("Username {} contains bad words")
+
+    if any(word in username for word in constants.RESRICTED_WORDS):
+        raise ValidationWarning("Username {} contains restricted words")
+
+
+def similarity_heuristic(realname, username):
+    """
+    Return a count of the edits that turn realname into username.
+
+    Count the number of replacements and insertions (*ignoring* deletions) for
+    the minimum number of edits (*including* deletions) that turn any of the
+    permutations of words orderings or initialisms of realname into username,
+    using the built-in difflib.SequenceMatcher class. SequenceMatcher finds the
+    longest continguous matching subsequence and continues this process
+    recursively.
+
+    This is usually the edit distance with zero deletion cost, but is
+    intentionally greater for longer realnames with short matching
+    subsequences, which are likely coincidental.
+
+    For most usernames based on real names, this number is 0."""
+
+    # The more words in realname, the more permutations. O(n!) is terrible!
+    max_words = 8
+    max_iterations = math.factorial(max_words)
+
+    words = re.findall("\w+", realname)
+    initials = [word[0] for word in words]
+
+    if len(words) > max_words:
+        print("Not trying all permutations of '{}' for similarity.".format(
+              realname))
+
+    distances = []
+    for sequence in [words, initials]:
+        for i, permutation in enumerate(itertools.permutations(sequence)):
+            if i > max_iterations:
+                break
+            s = "".join(permutation).lower()
+            matcher = difflib.SequenceMatcher(None, s, username)
+            edits = matcher.get_opcodes()
+            distance = sum(edit[4] - edit[3]
+                           for edit in edits
+                           if edit[0] in ["replace", "insert"])
+            if distance == 0:
+                # Edit distance cannot be smaller than 0, so return early.
+                return 0
+            distances.append(distance)
+    return min(distances)

--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -8,16 +8,16 @@ import sys
 
 import ocflib.account.search as search
 import ocflib.account.utils as utils
+import ocflib.account.validators as validators
 import ocflib.constants as constants
 import ocflib.misc.mail as mail
-import ocflib.validators as validators
 
 
 def create_home_dir(user):
     """Create home directory for user. Makes a directory with appropriate
     permissions, then copies in OCF's skeleton dotfiles."""
 
-    home = utils.home_dir(user['account_name'])
+    home = utils.home_dir(user)
     subprocess.check_call(
         ['sudo', 'install', '-d', '--mode=0700', '--group=ocf',
             '--owner=' + user, home],
@@ -133,7 +133,7 @@ def validate_calnet_uid(uid):
     # check if user is eligible for an account
     affiliations = attrs['berkeleyEduAffiliations']
     if not eligible_for_account(affiliations):
-        raise ValidationError(
+        raise ValidationWarning(
             "Affiliate type not eligible for account: " + str(affiliations))
 
 
@@ -195,7 +195,7 @@ def validate_username(username, realname):
     if any(word in username for word in constants.BAD_WORDS):
         raise ValidationWarning("Username {} contains bad words")
 
-    if any(word in username for word in constants.RESRICTED_WORDS):
+    if any(word in username for word in constants.RESTRICTED_WORDS):
         raise ValidationWarning("Username {} contains restricted words")
 
 

--- a/ocflib/account/manage.py
+++ b/ocflib/account/manage.py
@@ -1,5 +1,5 @@
-"""Module containing account management methods, such as password changing,
-account creation, etc."""
+"""Module containing account management methods, such as password changing, but
+not account creation (since it's too large)."""
 
 import base64
 import fcntl

--- a/ocflib/account/rc/bash_logout
+++ b/ocflib/account/rc/bash_logout
@@ -1,0 +1,4 @@
+# OCF config
+if [ -r /opt/ocf/share/environment/.bash_logout ]; then
+  source /opt/ocf/share/environment/.bash_logout
+fi

--- a/ocflib/account/rc/bash_profile
+++ b/ocflib/account/rc/bash_profile
@@ -1,0 +1,4 @@
+# OCF config
+if [ -r /opt/ocf/share/environment/.bash_profile ]; then
+  source /opt/ocf/share/environment/.bash_profile
+fi

--- a/ocflib/account/rc/bashrc
+++ b/ocflib/account/rc/bashrc
@@ -1,0 +1,4 @@
+# OCF config
+if [ -r /opt/ocf/share/environment/.bashrc ]; then
+  source /opt/ocf/share/environment/.bashrc
+fi

--- a/ocflib/constants.py
+++ b/ocflib/constants.py
@@ -52,6 +52,10 @@ https://ocf.io/ssh
 Need to reset your account password?
 https://ocf.io/password"""
 
+# words not allowed in usernames
+BAD_WORDS = ["fuck", "shit", "cunt", "crap", "bitch", "hell", "ass", "dick"]
+RESTRICTED_WORDS = ["ocf", "ucb", "cal"]
+
 # don't bother listing accounts starting with 'ocf' here;
 # those are always reserved
 RESERVED_USERNAMES = [

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -1,0 +1,164 @@
+import mock
+import os.path
+import pytest
+import sys
+
+import ocflib.account.creation
+from ocflib.account.creation import ValidationError
+from ocflib.account.creation import ValidationWarning
+from ocflib.account.creation import create_home_dir
+from ocflib.account.creation import create_web_dir
+from ocflib.account.creation import eligible_for_account
+from ocflib.account.creation import send_created_mail
+from ocflib.account.creation import send_rejected_mail
+from ocflib.account.creation import similarity_heuristic
+from ocflib.account.creation import validate_calnet_uid
+from ocflib.account.creation import validate_username
+
+class TestCreateDirectories:
+    @mock.patch('subprocess.check_call')
+    def test_create_home_dir(self, check_call):
+        create_home_dir('ckuehl')
+
+        calls = [mock.call(
+            ['sudo', 'install', '-d', '--mode=0700', '--group=ocf',
+                '--owner=ckuehl', '/home/c/ck/ckuehl'],
+            stdout=sys.stderr,
+        )]
+
+        for name in ['bashrc', 'bash_profile', 'bash_logout']:
+            path = os.path.join(os.path.dirname(ocflib.account.creation.__file__), 'rc', name)
+            calls.append(mock.call(
+                ['sudo', 'install', '--mode=0600', '--group=ocf',
+                    '--owner=ckuehl', path, '/home/c/ck/ckuehl/.' + name],
+                stdout=sys.stderr,
+            ))
+
+        check_call.assert_has_calls(calls)
+
+    @mock.patch('subprocess.check_call')
+    def test_create_web_dir(self, check_call):
+        create_web_dir('ckuehl')
+        check_call.assert_called_with(
+            ['sudo', 'install', '-d', '--mode=0000', '--group=ocf',
+                '--owner=ckuehl', '/services/http/users/c/ckuehl'],
+            stdout=sys.stderr)
+
+
+class TestUsernameBasedOnRealName:
+    @pytest.mark.parametrize("username,realname,success", [
+        ['ckuehl', 'Christopher Kuehl', True],
+        ['ckuehl', 'CHRISTOPHER B KUEHL', True],
+        ['kuehl', 'CHRISTOPHER B KUEHL', True],
+        ['cbk', 'CHRISTOPHER B KUEHL', True],
+
+        ['rejectme', 'Christopher Kuehl', False],
+        ['penguin', 'Christopher Kuehl', False],
+        ['daradib', 'Christopher Kuehl', False],
+    ])
+    @mock.patch('ocflib.account.validators.validate_username')
+    @mock.patch('ocflib.account.search.user_exists', return_value=False)
+    def test_some_names(self, _, __, username, realname, success,):
+        """Test some obviously good and bad usernames."""
+        try:
+            validate_username(username, realname)
+        except ValidationWarning as ex:
+            if success:
+                pytest.fail("Received unexpected error: {error}".format(error=ex))
+
+    @pytest.mark.parametrize("username", [
+        'shitup',
+        'hella',
+        'ucbcop',
+        'suxocf',
+    ])
+    @mock.patch('ocflib.account.search.user_exists', return_value=False)
+    @mock.patch('ocflib.account.creation.similarity_heuristic', return_value=0)
+    def test_warning_names(self, _, __, username):
+        """Ensure that we raise warnings when bad/restricted words appear."""
+        with pytest.raises(ValidationWarning):
+            validate_username(username, username)
+
+    @pytest.mark.parametrize("username", [
+        'wordpress',
+        'systemd',
+        'ocf',
+        'ocfrocks',
+    ])
+    @mock.patch('ocflib.account.search.user_exists', return_value=False)
+    @mock.patch('ocflib.account.creation.similarity_heuristic', return_value=0)
+    def test_error_names(self, _, __, username):
+        """Ensure that we raise errors when appropriate."""
+        with pytest.raises(ValidationError):
+            validate_username(username, username)
+
+    def test_error_user_exists(self):
+        """Ensure that we raise an error if the username already exists."""
+        with pytest.raises(ValidationError):
+            validate_username('ckuehl', "Chris Kuehl")
+
+    @mock.patch('ocflib.account.validators.validate_username')
+    @mock.patch('ocflib.account.search.user_exists', return_value=False)
+    def test_long_names(self, _, __):
+        """In the past, create has gotten "stuck" trying millions of
+        combinations of real names because we try permutations of the words in
+        the real name."""
+        with pytest.raises(ValidationWarning):
+            # 16! = 2.09227899e13, so if this works, it's definitely not
+            # because we tried all possibilities
+            validate_username(
+                "nomatch",
+                "I Have Sixteen Names A B C D E F G H I J K L",
+            )
+
+
+class TestAccountEligibility:
+    @pytest.mark.parametrize("bad_uid", [
+        1034192,    # good uid, but already has account
+        9999999999, # fake uid, not in university ldap
+    ])
+    def test_validate_calnet_uid_error(self, bad_uid):
+        with pytest.raises(ValidationError):
+            validate_calnet_uid(bad_uid)
+
+    @mock.patch('ocflib.account.search.user_attrs_ucb',
+            return_value={'berkeleyEduAffiliations': ['STUDENT-TYPE-REGISTERED']})
+    def test_validate_calnet_uid_success(self, _):
+        validate_calnet_uid(9999999999999)
+
+    @mock.patch('ocflib.account.search.user_attrs_ucb',
+            return_value={'berkeleyEduAffiliations': ['STUDENT-STATUS-EXPIRED']})
+    def test_validate_calnet_affiliations_failure(self, _):
+        with pytest.raises(ValidationWarning):
+            validate_calnet_uid(9999999999999)
+
+    @pytest.mark.parametrize("affiliations,eligible", [
+        (['AFFILIATE-TYPE-CONSULTANT'], True),
+        (['AFFILIATE-TYPE-CONSULTANT', 'AFFILIATE-STATUS-EXPIRED'], False),
+
+        (['EMPLOYEE-TYPE-ACADEMIC'], True),
+        (['EMPLOYEE-TYPE-STAFF'], True),
+        (['EMPLOYEE-TYPE-ACADEMIC', 'EMPLOYEE-STATUS-EXPIRED'], False),
+        (['EMPLOYEE-TYPE-ACADEMIC', 'EMPLOYEE-STATUS-EXPIRED', 'AFFILIATE-TYPE-CONSULTANT'], True),
+        (['EMPLOYEE-TYPE-ACADEMIC', 'EMPLOYEE-STATUS-EXPIRED', 'STUDENT-TYPE-REGISTERED'], True),
+
+        (['STUDENT-TYPE-REGISTERED'], True),
+        (['STUDENT-TYPE-REGISTERED', 'STUDENT-STATUS-EXPIRED'], False),
+        (['STUDENT-STATUS-EXPIRED'], False),
+
+        ([], False),
+    ])
+    def test_affiliations(self, affiliations, eligible):
+        assert eligible_for_account(affiliations) == eligible
+
+
+class TestSendMail:
+    @mock.patch('ocflib.misc.mail.send_mail')
+    def test_send_created_mail(self, send_mail):
+        send_created_mail('email', 'realname', 'username')
+        send_mail.assert_called()
+
+    @mock.patch('ocflib.misc.mail.send_mail')
+    def test_send_rejected_mail(self, send_mail):
+        send_rejected_mail('email', 'realname', 'username', 'reason')
+        send_mail.assert_called()


### PR DESCRIPTION
This imports a lot of code from create, which was written collectively
by OCF staffers, but especially:

- Nader Morshed <morshed@ocf.berkeley.edu> (primary author)
- Kenny Do <kedo@ocf.berkeley.edu> (account filtering)
- Dara Adib <daradib@ocf.berkeley.edu> (realname checking, minor fixes)

Much of the code has been reorganized or slightly rewritten in
preparation of switching to single-account-transaction account creation
(rather than batch processing of several accounts at once).

Since we also no longer use the 'mid' stage of account creation (where
accounts have been approved, but wait 24 hours to be created), that code
is also removed.

Currently, this imports most of the account filtering, but not all of
the account creation. The main things still remaining are:

* LDAP entry creation
* Kerberos principal creation

There are some smaller things still remaining as well:

* Getting max UID