### PR TITLE
Cache known UID in module

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,6 @@ coverage==3.7.1
 coveralls
 freezegun
 mock
+pre-commit
 pytest
 twine


### PR DESCRIPTION
We can cache the known UID with a slight hack and prime the cache
on import. If accounts are deleted, UIDs could be skipped.
Cache is not shared across multiple processes.