### PR TITLE
Remove middle names shown on staff hours

### DIFF
--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -57,7 +57,7 @@ def get_staff_hours():
             staff=[
                 Staffer(
                     user_name=attrs['uid'][0],
-                    real_name=remove_middle_names(attrs['cn'][0]),
+                    real_name=_remove_middle_names(attrs['cn'][0]),
                     position=position(attrs['uid'][0]),
                 ) for attrs in map(user_attrs, hour['staff'])
             ],
@@ -66,9 +66,9 @@ def get_staff_hours():
     ]
 
 
-def remove_middle_names(name):
-    names = name.split(" ")
-    return names[0] + " " + names[-1]
+def _remove_middle_names(name):
+    names = name.split(' ')
+    return names[0] + ' ' + names[-1]
 
 
 def get_staff_hours_soonest_first():

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -57,13 +57,18 @@ def get_staff_hours():
             staff=[
                 Staffer(
                     user_name=attrs['uid'][0],
-                    real_name=attrs['cn'][0],
+                    real_name=remove_middle_names(attrs['cn'][0]),
                     position=position(attrs['uid'][0]),
                 ) for attrs in map(user_attrs, hour['staff'])
             ],
             cancelled=hour['cancelled'],
         ) for hour in staff_hours['staff-hours']
     ]
+
+
+def remove_middle_names(name):
+    names = name.split(" ")
+    return names[0] + " " + names[-1]
 
 
 def get_staff_hours_soonest_first():


### PR DESCRIPTION
This pull request removes the middle names currently shown on the [staff hours page](https://ocf.berkeley.edu/staff-hours). That's about it!