### PR TITLE
Reserve usernames of some former staffers whose accounts have been lost

### DIFF
--- a/ocflib/constants.py
+++ b/ocflib/constants.py
@@ -224,6 +224,31 @@ RESERVED_USERNAMES = frozenset((
     'www',
     'www-data',
     'zabbix',
+# Some usernames belonging to former staffers whose accounts were later lost
+    'adamj',    # Adam Richter
+    'anniem',   # Ann Matsubara
+    'appel',
+    'blojo',    # Jon Blow
+    'chamm',
+    'chaynges', # Cynthia Haynes
+    'cjain',    # Chris Jain
+    'dpassage', # David Paschich
+    'euphrasi',
+    'evil',
+    'glass',    # Adam Glass
+    'ianb',
+    'karat',    # Eddy Karat
+    'kinshuk',  # Kinshuk Govil
+    'kit',
+    'marko',    # Mark Nolte
+    'moray',
+    'nweaver',  # Nicholas Weaver
+    'pbrown',
+    'reiser',   # Hans Reiser
+    'rgm',      # Rob Menke
+    'steveg',
+    'welch',    # Sean Welch
+    'yukai',
 ))
 
 CREATE_PUBLIC_KEY = """\


### PR DESCRIPTION
So we won't have more problems with random future members being confused with
old board members, or more significantly User_Info entries incorrectly
labeling new members as such