### PR TITLE
Add quota schema and simple functions for manipulating it

### DIFF
--- a/ocflib/lab/stats.py
+++ b/ocflib/lab/stats.py
@@ -36,6 +36,13 @@ UserTime = namedtuple('UserTime', ['user', 'time'])
 
 
 def get_connection(user='anonymous', password=None):
+    """Return a connection to MySQL.
+
+    By default, returns an unprivileged connection which can be used for
+    querying most data.
+
+    If you need rw access, pass a user and password argument.
+    """
     return pymysql.connect(
         host='mysql.ocf.berkeley.edu',
         user=user,

--- a/ocflib/printing/ocfprinting.sql
+++ b/ocflib/printing/ocfprinting.sql
@@ -24,9 +24,7 @@ CREATE TABLE IF NOT EXISTS `refunds` (
     PRIMARY KEY(`id`)
 ) ENGINE=InnoDB;
 
-DROP INDEX jobs_idx on jobs;
 CREATE INDEX `jobs_idx` ON `jobs` (`user`, `time`, `pages`);
-DROP INDEX refunds_idx on refunds;
 CREATE INDEX `refunds_idx` ON `refunds` (`user`, `time`, `pages`);
 
 DROP FUNCTION IF EXISTS semester_start;
@@ -59,7 +57,7 @@ CREATE VIEW `printed_today` AS
         COALESCE(SUM(jobs_today.pages), 0) - COALESCE(SUM(refunds_today.pages), 0) AS today
     FROM jobs_today
     LEFT OUTER JOIN refunds_today
-    WHERE jobs_today.user = refunds_today.user
+    ON jobs_today.user = refunds_today.user
     GROUP BY jobs_today.user
     ORDER BY user;
 
@@ -80,7 +78,7 @@ CREATE VIEW `printed_semester` AS
         COALESCE(SUM(jobs_semester.pages), 0) - COALESCE(SUM(refunds_semester.pages), 0) AS semester
     FROM jobs_semester
     LEFT OUTER JOIN refunds_semester
-    WHERE jobs_semester.user = refunds_semester.user
+    ON jobs_semester.user = refunds_semester.user
     GROUP BY jobs_semester.user
     ORDER BY user;
 

--- a/ocflib/printing/ocfprinting.sql
+++ b/ocflib/printing/ocfprinting.sql
@@ -1,0 +1,98 @@
+--
+-- This is kept here mostly to allow us to document the existing schema.
+--
+
+CREATE TABLE IF NOT EXISTS `jobs` (
+    `id` int NOT NULL AUTO_INCREMENT,
+    `user` varchar(255) NOT NULL,
+    `time` datetime NOT NULL,
+    `pages` int unsigned NOT NULL,
+    `queue` varchar(255) NOT NULL,
+    `printer` varchar(255) NOT NULL,
+    `doc_name` varchar(510) NOT NULL,
+    `filesize` int unsigned NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `refunds` (
+    `id` int NOT NULL AUTO_INCREMENT,
+    `user` varchar(255) NOT NULL,
+    `time` datetime NOT NULL,
+    `pages` int NOT NULL,
+    `staffer` varchar(255) NOT NULL,
+    `reason` varchar(510) NOT NULL,
+    PRIMARY KEY(`id`)
+) ENGINE=InnoDB;
+
+DROP INDEX jobs_idx on jobs;
+CREATE INDEX `jobs_idx` ON `jobs` (`user`, `time`, `pages`);
+DROP INDEX refunds_idx on refunds;
+CREATE INDEX `refunds_idx` ON `refunds` (`user`, `time`, `pages`);
+
+DROP FUNCTION IF EXISTS semester_start;
+DELIMITER $$
+CREATE FUNCTION semester_start (d date) RETURNS date
+        DETERMINISTIC
+        BEGIN
+        IF MONTH(d) > 8 THEN
+            RETURN MAKEDATE(YEAR(d), 213);  -- roughly august 1st
+        ELSE
+            RETURN MAKEDATE(YEAR(d), 1);
+        END IF;
+    END$$
+DELIMITER ;
+
+DROP VIEW IF EXISTS jobs_today;
+CREATE VIEW jobs_today AS
+    SELECT * FROM jobs
+    WHERE DATE(jobs.time) = CURDATE();
+
+DROP VIEW IF EXISTS refunds_today;
+CREATE VIEW refunds_today AS
+    SELECT * FROM refunds
+    WHERE DATE(refunds.time) = CURDATE();
+
+DROP VIEW IF EXISTS printed_today;
+CREATE VIEW `printed_today` AS
+    SELECT
+        jobs_today.user AS user,
+        COALESCE(SUM(jobs_today.pages), 0) - COALESCE(SUM(refunds_today.pages), 0) AS today
+    FROM jobs_today
+    LEFT OUTER JOIN refunds_today
+    WHERE jobs_today.user = refunds_today.user
+    GROUP BY jobs_today.user
+    ORDER BY user;
+
+DROP VIEW IF EXISTS jobs_semester;
+CREATE VIEW jobs_semester AS
+    SELECT * FROM jobs
+    WHERE DATE(jobs.time) > semester_start(CURDATE());
+
+DROP VIEW IF EXISTS refunds_semester;
+CREATE VIEW refunds_semester AS
+    SELECT * FROM refunds
+    WHERE DATE(refunds.time) > semester_start(CURDATE());
+
+DROP VIEW IF EXISTS printed_semester;
+CREATE VIEW `printed_semester` AS
+    SELECT
+        jobs_semester.user AS user,
+        COALESCE(SUM(jobs_semester.pages), 0) - COALESCE(SUM(refunds_semester.pages), 0) AS semester
+    FROM jobs_semester
+    LEFT OUTER JOIN refunds_semester
+    WHERE jobs_semester.user = refunds_semester.user
+    GROUP BY jobs_semester.user
+    ORDER BY user;
+
+DROP VIEW IF EXISTS printed;
+CREATE VIEW `printed` AS
+    SELECT
+        printed_today.user AS user,
+        printed_today.today AS today,
+        printed_semester.semester AS semester
+    FROM printed_today
+    RIGHT OUTER JOIN printed_semester
+    ON printed_today.user = printed_semester.user
+    ORDER BY user;
+
+GRANT SELECT ON `ocfprinting`.`printed` TO 'anonymous'@'%';

--- a/ocflib/printing/quota.py
+++ b/ocflib/printing/quota.py
@@ -170,9 +170,9 @@ def get_schema():
                 DETERMINISTIC
                 BEGIN
                 IF MONTH(d) > 8 THEN
-                    RETURN MAKEDATE(YEAR(d), 213);
+                    RETURN MAKEDATE(YEAR(d), 213);  -- roughly august 1st
                 ELSE
-                        RETURN MAKEDATE(YEAR(d), 1);
+                    RETURN MAKEDATE(YEAR(d), 1);
                 END IF;
             END$$
         DELIMITER ;

--- a/ocflib/printing/quota.py
+++ b/ocflib/printing/quota.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from datetime import datetime
-from textwrap import dedent
 
 import pymysql
 
@@ -69,46 +68,32 @@ def get_quota(c, user):
     )
 
 
+def _namedtuple_to_query(query, nt):
+    """Return a filled-out query and arguments.
+
+    The return value can be exploded and passed directly into execute.
+
+    >>> query = 'INSERT INTO jobs ({}) VALUES ({});'
+    >>> namedtuple_to_query(query, job)
+    ('INSERT INTO jobs (`user`, `pages`) VALUES (%s, %s)', ('ckuehl', 42))
+    """
+    return (
+        query.format(
+            ', '.join('`{}`'.format(column) for column in nt._fields),
+            ', '.join('%s' for _ in nt._fields),
+        ),
+        tuple(getattr(nt, column) for column in nt._fields),
+    )
+
+
 def add_job(c, job):
     """Add a new job to the database."""
-    c.execute(
-        '''
-        INSERT INTO
-            `jobs`
-                (`user`, `time`, `pages`, `queue`, `printer`, `doc_name`, `filesize`)
-            VALUES
-                (%s, %s, %s, %s, %s, %s, %s);
-        ''',
-        (
-            job.user,
-            job.time,
-            job.pages,
-            job.queue,
-            job.printer,
-            job.doc_name,
-            job.filesize,
-        ),
-    )
+    c.execute(*_namedtuple_to_query('INSERT INTO jobs ({}) VALUES ({})', job))
 
 
 def add_refund(c, refund):
     """Add a new refund to the database."""
-    c.execute(
-        '''
-        INSERT INTO
-            `refunds`
-                (`user`, `time`, `pages`, `staffer`, `reason`)
-            VALUES
-                (%s, %s, %s, %s, %s);
-        ''',
-        (
-            refund.user,
-            refund.time,
-            refund.pages,
-            refund.staffer,
-            refund.reason
-        ),
-    )
+    c.execute(*_namedtuple_to_query('INSERT INTO refunds ({}) VALUES ({})', refund))
 
 
 def get_connection(user='anonymous', password=None):
@@ -127,110 +112,3 @@ def get_connection(user='anonymous', password=None):
         cursorclass=pymysql.cursors.DictCursor,
         autocommit=True,
     )
-
-
-def get_schema():
-    """Return the printing schema.
-
-    Normally, this never needs to be called and just exists to document the
-    existing schema.
-    """
-    schema = dedent(
-        '''\
-        CREATE TABLE IF NOT EXISTS `jobs` (
-            `id` int NOT NULL AUTO_INCREMENT,
-            `user` varchar(255) NOT NULL,
-            `time` datetime NOT NULL,
-            `pages` int unsigned NOT NULL,
-            `queue` varchar(255) NOT NULL,
-            `printer` varchar(255) NOT NULL,
-            `doc_name` varchar(510) NOT NULL,
-            `filesize` int unsigned NOT NULL,
-            PRIMARY KEY (`id`)
-        ) ENGINE=InnoDB;
-
-        CREATE TABLE IF NOT EXISTS `refunds` (
-            `id` int NOT NULL AUTO_INCREMENT,
-            `user` varchar(255) NOT NULL,
-            `time` datetime NOT NULL,
-            `pages` int NOT NULL,
-            `staffer` varchar(255) NOT NULL,
-            `reason` varchar(510) NOT NULL,
-            PRIMARY KEY(`id`)
-        ) ENGINE=InnoDB;
-
-        DROP INDEX jobs_idx on jobs;
-        CREATE INDEX `jobs_idx` ON `jobs` (`user`, `time`, `pages`);
-        DROP INDEX refunds_idx on refunds;
-        CREATE INDEX `refunds_idx` ON `refunds` (`user`, `time`, `pages`);
-
-        DROP FUNCTION IF EXISTS semester_start;
-        DELIMITER $$
-        CREATE FUNCTION semester_start (d date) RETURNS date
-                DETERMINISTIC
-                BEGIN
-                IF MONTH(d) > 8 THEN
-                    RETURN MAKEDATE(YEAR(d), 213);  -- roughly august 1st
-                ELSE
-                    RETURN MAKEDATE(YEAR(d), 1);
-                END IF;
-            END$$
-        DELIMITER ;
-
-        DROP VIEW IF EXISTS jobs_today;
-        CREATE VIEW jobs_today AS
-            SELECT * FROM jobs
-            WHERE DATE(jobs.time) = CURDATE();
-
-        DROP VIEW IF EXISTS refunds_today;
-        CREATE VIEW refunds_today AS
-            SELECT * FROM refunds
-            WHERE DATE(refunds.time) = CURDATE();
-
-        DROP VIEW IF EXISTS printed_today;
-        CREATE VIEW `printed_today` AS
-            SELECT
-                jobs.user AS user,
-                COALESCE(SUM(jobs.pages), 0) - COALESCE(SUM(refunds.pages), 0) AS today
-            FROM jobs_today AS jobs
-            LEFT OUTER JOIN refunds_today AS refunds
-            ON jobs.user = refunds.user
-            GROUP BY jobs.user
-            ORDER BY user;
-
-        DROP VIEW IF EXISTS jobs_semester;
-        CREATE VIEW jobs_semester AS
-            SELECT * FROM jobs
-            WHERE DATE(jobs.time) > semester_start(CURDATE());
-
-        DROP VIEW IF EXISTS refunds_semester;
-        CREATE VIEW refunds_semester AS
-            SELECT * FROM refunds
-            WHERE DATE(refunds.time) > semester_start(CURDATE());
-
-        DROP VIEW IF EXISTS printed_semester;
-        CREATE VIEW `printed_semester` AS
-            SELECT
-                jobs.user AS user,
-                COALESCE(SUM(jobs.pages), 0) - COALESCE(SUM(refunds.pages), 0) AS semester
-            FROM jobs_semester AS jobs
-            LEFT OUTER JOIN refunds_semester AS refunds
-            ON jobs.user = refunds.user
-            GROUP BY jobs.user
-            ORDER BY user;
-
-        DROP VIEW IF EXISTS printed;
-        CREATE VIEW `printed` AS
-            SELECT
-                printed_today.user AS user,
-                printed_today.today AS today,
-                printed_semester.semester AS semester
-            FROM printed_today
-            RIGHT OUTER JOIN printed_semester
-            ON printed_today.user = printed_semester.user
-            ORDER BY user;
-
-        GRANT SELECT ON `ocfprinting`.`printed` TO 'anonymous'@'%';
-        ''',
-    )
-    return schema

--- a/ocflib/printing/quota.py
+++ b/ocflib/printing/quota.py
@@ -1,0 +1,236 @@
+from collections import namedtuple
+from datetime import datetime
+from textwrap import dedent
+
+import pymysql
+
+
+WEEKDAY_QUOTA = 8
+WEEKEND_QUOTA = 16
+SEMESTERLY_QUOTA = 100
+
+UserQuota = namedtuple('UserQuota', (
+    'user',
+    'daily',
+    'semesterly',
+))
+
+
+Job = namedtuple('Job', (
+    'user',
+    'time',
+    'pages',
+    'queue',
+    'printer',
+    'doc_name',
+    'filesize',
+))
+
+Refund = namedtuple('Refund', (
+    'user',
+    'time',
+    'pages',
+    'staffer',
+    'reason',
+))
+
+
+def daily_quota(day=None):
+    """Return the daily quota for a given day.
+
+    :param day: date object (defaults to today)
+    """
+    if day is None:
+        day = datetime.today()
+
+    if day.weekday() in {5, 6}:
+        return WEEKEND_QUOTA
+    else:
+        return WEEKDAY_QUOTA
+
+
+def get_quota(c, user):
+    """Return a UserQuota representing the user's quota."""
+    if user == 'pubstaff':
+        return UserQuota('pubstaff', 500, 500)
+
+    c.execute(
+        'SELECT `today`, `semester` FROM `printed` WHERE `user` = %s',
+        (user,)
+    )
+
+    row = c.fetchone()
+    if not row:
+        row = {'today': 0, 'semester': 0}
+    return UserQuota(
+        user=user,
+        daily=daily_quota() - int(row['today']),
+        semesterly=SEMESTERLY_QUOTA - int(row['semester']),
+    )
+
+
+def add_job(c, job):
+    """Add a new job to the database."""
+    c.execute(
+        '''
+        INSERT INTO
+            `jobs`
+                (`user`, `time`, `pages`, `queue`, `printer`, `doc_name`, `filesize`)
+            VALUES
+                (%s, %s, %s, %s, %s, %s, %s);
+        ''',
+        (
+            job.user,
+            job.time,
+            job.pages,
+            job.queue,
+            job.printer,
+            job.doc_name,
+            job.filesize,
+        ),
+    )
+
+
+def add_refund(c, refund):
+    """Add a new refund to the database."""
+    c.execute(
+        '''
+        INSERT INTO
+            `refunds`
+                (`user`, `time`, `pages`, `staffer`, `reason`)
+            VALUES
+                (%s, %s, %s, %s, %s);
+        ''',
+        (
+            refund.user,
+            refund.time,
+            refund.pages,
+            refund.staffer,
+            refund.reason
+        ),
+    )
+
+
+def get_connection(user='anonymous', password=None):
+    """Return a connection to MySQL.
+
+    By default, returns an unprivileged connection which can be used for
+    querying most data.
+
+    If you need rw access, pass a user and password argument.
+    """
+    return pymysql.connect(
+        host='mysql.ocf.berkeley.edu',
+        user=user,
+        password=password,
+        db='ocfprinting',
+        cursorclass=pymysql.cursors.DictCursor,
+        autocommit=True,
+    )
+
+
+def get_schema():
+    """Return the printing schema.
+
+    Normally, this never needs to be called and just exists to document the
+    existing schema.
+    """
+    schema = dedent(
+        '''\
+        CREATE TABLE IF NOT EXISTS `jobs` (
+            `id` int NOT NULL AUTO_INCREMENT,
+            `user` varchar(255) NOT NULL,
+            `time` datetime NOT NULL,
+            `pages` int unsigned NOT NULL,
+            `queue` varchar(255) NOT NULL,
+            `printer` varchar(255) NOT NULL,
+            `doc_name` varchar(510) NOT NULL,
+            `filesize` int unsigned NOT NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB;
+
+        CREATE TABLE IF NOT EXISTS `refunds` (
+            `id` int NOT NULL AUTO_INCREMENT,
+            `user` varchar(255) NOT NULL,
+            `time` datetime NOT NULL,
+            `pages` int NOT NULL,
+            `staffer` varchar(255) NOT NULL,
+            `reason` varchar(510) NOT NULL,
+            PRIMARY KEY(`id`)
+        ) ENGINE=InnoDB;
+
+        DROP INDEX jobs_idx on jobs;
+        CREATE INDEX `jobs_idx` ON `jobs` (`user`, `time`, `pages`);
+        DROP INDEX refunds_idx on refunds;
+        CREATE INDEX `refunds_idx` ON `refunds` (`user`, `time`, `pages`);
+
+        DROP FUNCTION IF EXISTS semester_start;
+        DELIMITER $$
+        CREATE FUNCTION semester_start (d date) RETURNS date
+                DETERMINISTIC
+                BEGIN
+                IF MONTH(d) > 8 THEN
+                    RETURN MAKEDATE(YEAR(d), 213);
+                ELSE
+                        RETURN MAKEDATE(YEAR(d), 1);
+                END IF;
+            END$$
+        DELIMITER ;
+
+        DROP VIEW IF EXISTS jobs_today;
+        CREATE VIEW jobs_today AS
+            SELECT * FROM jobs
+            WHERE DATE(jobs.time) = CURDATE();
+
+        DROP VIEW IF EXISTS refunds_today;
+        CREATE VIEW refunds_today AS
+            SELECT * FROM refunds
+            WHERE DATE(refunds.time) = CURDATE();
+
+        DROP VIEW IF EXISTS printed_today;
+        CREATE VIEW `printed_today` AS
+            SELECT
+                jobs.user AS user,
+                COALESCE(SUM(jobs.pages), 0) - COALESCE(SUM(refunds.pages), 0) AS today
+            FROM jobs_today AS jobs
+            LEFT OUTER JOIN refunds_today AS refunds
+            ON jobs.user = refunds.user
+            GROUP BY jobs.user
+            ORDER BY user;
+
+        DROP VIEW IF EXISTS jobs_semester;
+        CREATE VIEW jobs_semester AS
+            SELECT * FROM jobs
+            WHERE DATE(jobs.time) > semester_start(CURDATE());
+
+        DROP VIEW IF EXISTS refunds_semester;
+        CREATE VIEW refunds_semester AS
+            SELECT * FROM refunds
+            WHERE DATE(refunds.time) > semester_start(CURDATE());
+
+        DROP VIEW IF EXISTS printed_semester;
+        CREATE VIEW `printed_semester` AS
+            SELECT
+                jobs.user AS user,
+                COALESCE(SUM(jobs.pages), 0) - COALESCE(SUM(refunds.pages), 0) AS semester
+            FROM jobs_semester AS jobs
+            LEFT OUTER JOIN refunds_semester AS refunds
+            ON jobs.user = refunds.user
+            GROUP BY jobs.user
+            ORDER BY user;
+
+        DROP VIEW IF EXISTS printed;
+        CREATE VIEW `printed` AS
+            SELECT
+                printed_today.user AS user,
+                printed_today.today AS today,
+                printed_semester.semester AS semester
+            FROM printed_today
+            RIGHT OUTER JOIN printed_semester
+            ON printed_today.user = printed_semester.user
+            ORDER BY user;
+
+        GRANT SELECT ON `ocfprinting`.`printed` TO 'anonymous'@'%';
+        ''',
+    )
+    return schema

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://www.ocf.berkeley.edu',
     packages=find_packages(),
     package_data={
-        'ocflib.account': ['rc/*'],
+        'ocflib.printing': ['ocfprinting.schema'],
     },
     install_requires=(
         'cached_property',

--- a/tests-manual/printing/add_job.py
+++ b/tests-manual/printing/add_job.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Add a test job."""
+import getpass
+import random
+import string
+from datetime import datetime
+
+from ocflib.printing.printers import PRINTERS
+from ocflib.printing.quota import add_job
+from ocflib.printing.quota import get_connection
+from ocflib.printing.quota import Job
+
+
+if __name__ == '__main__':
+    user = 'ocfprinting'
+    password = getpass.getpass('{} password: '.format(user))
+    with get_connection(user=user, password=password) as c:
+        add_job(
+            c,
+            Job(
+                user=input('user: '),
+                time=datetime.now(),
+                pages=int(input('pages: ')),
+                queue=random.choice(('single', 'double')),
+                printer=random.choice(tuple(PRINTERS)),
+                doc_name=''.join(
+                    random.choice(string.ascii_letters) for _ in range(30)
+                ),
+                filesize=random.randint(0, 2**28),
+            ),
+        )

--- a/tests-manual/printing/add_refund.py
+++ b/tests-manual/printing/add_refund.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Add a test job."""
+"""Add a test refund."""
 import getpass
 import random
 import string

--- a/tests-manual/printing/add_refund.py
+++ b/tests-manual/printing/add_refund.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Add a test job."""
+import getpass
+import random
+import string
+from datetime import datetime
+
+from ocflib.printing.quota import add_refund
+from ocflib.printing.quota import get_connection
+from ocflib.printing.quota import Refund
+
+
+if __name__ == '__main__':
+    user = 'ocfprinting'
+    password = getpass.getpass('{} password: '.format(user))
+    with get_connection(user=user, password=password) as c:
+        add_refund(
+            c,
+            Refund(
+                user=input('user: '),
+                time=datetime.now(),
+                pages=int(input('pages: ')),
+                staffer=getpass.getuser(),
+                reason=''.join(
+                    random.choice(string.ascii_letters) for _ in range(30)
+                ),
+            ),
+        )

--- a/tests-manual/printing/init_schema.py
+++ b/tests-manual/printing/init_schema.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Initialize the ocfprinting DB schema."""
+"""Print the ocfprinting DB schema, to be piped to mysql."""
 from ocflib.printing.quota import get_schema
 
 

--- a/tests-manual/printing/init_schema.py
+++ b/tests-manual/printing/init_schema.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Initialize the ocfprinting DB schema."""
+from ocflib.printing.quota import get_schema
+
+
+if __name__ == '__main__':
+    print(get_schema())

--- a/tests-manual/printing/init_schema.py
+++ b/tests-manual/printing/init_schema.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-"""Print the ocfprinting DB schema, to be piped to mysql."""
-from ocflib.printing.quota import get_schema
-
-
-if __name__ == '__main__':
-    print(get_schema())

--- a/tests-manual/printing/paper.py
+++ b/tests-manual/printing/paper.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Add a test job."""
+from ocflib.printing.quota import get_connection
+from ocflib.printing.quota import get_quota
+
+
+if __name__ == '__main__':
+    with get_connection() as c:
+        print(get_quota(c, input('user: ')))

--- a/tests-manual/printing/paper.py
+++ b/tests-manual/printing/paper.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Add a test job."""
+"""Print the quota of a user."""
 from ocflib.printing.quota import get_connection
 from ocflib.printing.quota import get_quota
 

--- a/tests/printing/quota_test.py
+++ b/tests/printing/quota_test.py
@@ -213,6 +213,7 @@ def mysqld_socket(mysqld_path, tmpdir_factory):
 
     check_call((
         mysqld_path.join('usr', 'bin', 'mysql_install_db').strpath,
+        '--no-defaults',
         '--basedir=' + mysqld_path.join('usr').strpath,
         '--datadir=' + data_dir.strpath,
     ))

--- a/tests/printing/quota_test.py
+++ b/tests/printing/quota_test.py
@@ -1,0 +1,270 @@
+import random
+import string
+import time
+from datetime import datetime
+from datetime import timedelta
+from subprocess import check_call
+from subprocess import PIPE
+from subprocess import Popen
+
+import pkg_resources
+import pymysql
+import pytest
+from freezegun import freeze_time
+
+from ocflib.printing.quota import add_job
+from ocflib.printing.quota import add_refund
+from ocflib.printing.quota import daily_quota
+from ocflib.printing.quota import get_quota
+from ocflib.printing.quota import Job
+from ocflib.printing.quota import Refund
+from ocflib.printing.quota import SEMESTERLY_QUOTA
+from ocflib.printing.quota import UserQuota
+from ocflib.printing.quota import WEEKDAY_QUOTA
+from ocflib.printing.quota import WEEKEND_QUOTA
+
+
+MYSQL_TIMEOUT = 10
+TEST_JOB = Job(
+    user='nobody',
+    time=datetime.now(),
+    pages=3,
+    queue='double',
+    printer='logjam',
+    doc_name='asdf',
+    filesize=12,
+)
+TEST_REFUND = Refund(
+    user='nobody',
+    time=datetime.now(),
+    pages=3,
+    staffer='ckuehl',
+    reason='just because',
+)
+
+
+@pytest.mark.parametrize('time,expected', [
+    ('2015-08-22', WEEKEND_QUOTA),  # Saturday
+    ('2015-08-23', WEEKEND_QUOTA),  # Sunday
+    ('2015-08-24', WEEKDAY_QUOTA),  # Monday
+    ('2015-08-25', WEEKDAY_QUOTA),  # Tuesday
+    ('2015-08-26', WEEKDAY_QUOTA),  # Wednesday
+])
+def test_daily_quota(time, expected):
+    """Test that the daily quota returns reasonable things."""
+    time = datetime.strptime(time, '%Y-%m-%d')
+    with freeze_time(time):
+        assert daily_quota() == expected
+    assert daily_quota(time) == expected
+
+
+def test_quotas_are_sane():
+    assert SEMESTERLY_QUOTA > 0
+    assert WEEKDAY_QUOTA > 0
+    assert WEEKEND_QUOTA > WEEKDAY_QUOTA
+    assert WEEKDAY_QUOTA < SEMESTERLY_QUOTA
+    assert WEEKEND_QUOTA < SEMESTERLY_QUOTA
+
+
+@pytest.mark.parametrize('user', ('nobody', 'ckuehl'))
+def test_quota_user_not_in_db(user, mysql_connection):
+    assert (
+        get_quota(mysql_connection, user) ==
+        UserQuota(user, daily_quota(), SEMESTERLY_QUOTA)
+    )
+
+
+def test_pubstaff_has_infinite_quota(mysql_connection):
+    assert (
+        get_quota(mysql_connection, 'pubstaff') ==
+        UserQuota('pubstaff', 500, 500)
+    )
+
+
+def assert_quota(c, user, diff_daily, diff_semesterly):
+    """Assert the quota for a user is what we expect.
+
+    Typically, you want to pass a negative number for diff_daily and
+    diff_semesterly. This number is added to the start quota before assertion.
+    """
+    start = daily_quota(), SEMESTERLY_QUOTA
+    assert (
+        get_quota(c, user) ==
+        UserQuota(user, start[0] + diff_daily, start[1] + diff_semesterly)
+    )
+
+
+def test_several_jobs_today(mysql_connection):
+    """Multiple jobs should decrease quota correctly."""
+    assert_quota(mysql_connection, 'nobody', 0, 0)
+
+    add_job(mysql_connection, TEST_JOB._replace(pages=3))
+    assert_quota(mysql_connection, 'nobody', -3, -3)
+
+    add_job(mysql_connection, TEST_JOB._replace(pages=8))
+    assert_quota(mysql_connection, 'nobody', -11, -11)
+
+    # now add another user
+    assert_quota(mysql_connection, 'somebody', 0, 0)
+
+    add_job(mysql_connection, TEST_JOB._replace(pages=5, user='somebody'))
+    assert_quota(mysql_connection, 'somebody', -5, -5)
+    assert_quota(mysql_connection, 'nobody', -11, -11)
+
+
+def test_several_jobs_previous_days_and_semesters(mysql_connection):
+    """Multiple jobs should decrease quota correctly over different days,
+    semesters, and users."""
+    TODAY = datetime.today()
+    YESTERDAY = TODAY - timedelta(days=1)
+    LAST_SEMESTER = TODAY - timedelta(days=365)
+
+    for user in ('nobody', 'somebody', 'yobody'):
+        assert_quota(mysql_connection, user, 0, 0)
+
+        # add some jobs today
+        add_job(mysql_connection, TEST_JOB._replace(user=user, pages=1, time=TODAY))
+        assert_quota(mysql_connection, user, -1, -1)
+
+        add_job(mysql_connection, TEST_JOB._replace(user=user, pages=2, time=TODAY))
+        assert_quota(mysql_connection, user, -3, -3)
+
+        # add some jobs yesterday
+        add_job(mysql_connection, TEST_JOB._replace(user=user, pages=3, time=YESTERDAY))
+        assert_quota(mysql_connection, user, -3, -6)
+
+        add_job(mysql_connection, TEST_JOB._replace(user=user, pages=5, time=YESTERDAY))
+        assert_quota(mysql_connection, user, -3, -11)
+
+        # add some jobs last semester
+        add_job(mysql_connection, TEST_JOB._replace(user=user, pages=8, time=LAST_SEMESTER))
+        assert_quota(mysql_connection, user, -3, -11)
+
+        add_job(mysql_connection, TEST_JOB._replace(user=user, pages=13, time=LAST_SEMESTER))
+        assert_quota(mysql_connection, user, -3, -11)
+
+
+def test_jobs_and_refunds_today(mysql_connection):
+    """Refunds should add back pages correctly."""
+    assert_quota(mysql_connection, 'nobody', 0, 0)
+
+    add_job(mysql_connection, TEST_JOB._replace(pages=3))
+    assert_quota(mysql_connection, 'nobody', -3, -3)
+
+    add_job(mysql_connection, TEST_JOB._replace(pages=5))
+    assert_quota(mysql_connection, 'nobody', -8, -8)
+
+    add_refund(mysql_connection, TEST_REFUND._replace(pages=1))
+    assert_quota(mysql_connection, 'nobody', -7, -7)
+
+    add_refund(mysql_connection, TEST_REFUND._replace(pages=3))
+    assert_quota(mysql_connection, 'nobody', -4, -4)
+
+    # now add another user
+    assert_quota(mysql_connection, 'somebody', 0, 0)
+
+    add_job(mysql_connection, TEST_JOB._replace(pages=5, user='somebody'))
+    assert_quota(mysql_connection, 'somebody', -5, -5)
+    assert_quota(mysql_connection, 'nobody', -4, -4)
+
+    # and another refund for that user
+    add_refund(mysql_connection, TEST_REFUND._replace(pages=8, user='somebody'))
+    assert_quota(mysql_connection, 'somebody', 3, 3)
+    assert_quota(mysql_connection, 'nobody', -4, -4)
+
+
+@pytest.fixture(scope='session')
+def mysqld_path(tmpdir_factory):
+    """Download and extract a local copy of mysqld."""
+    tmpdir = tmpdir_factory.mktemp('mysql')
+    with tmpdir.as_cwd():
+        check_call(('apt-get', 'download', 'mariadb-server-10.0'))
+        check_call(('apt-get', 'download', 'mariadb-server-core-10.0'))
+        check_call(('apt-get', 'download', 'mariadb-client-core-10.0'))
+        for deb in tmpdir.listdir(lambda f: f.fnmatch('*.deb')):
+            check_call(('dpkg', '-x', deb.strpath, '.'))
+    return tmpdir
+
+
+@pytest.yield_fixture(scope='session')
+def mysqld_socket(mysqld_path, tmpdir_factory):
+    """Yield a socket to a running MySQL instance."""
+    tmpdir = tmpdir_factory.mktemp('var')
+    socket = tmpdir.join('socket')
+    data_dir = tmpdir.join('data')
+    data_dir.ensure_dir()
+
+    check_call((
+        mysqld_path.join('usr', 'bin', 'mysql_install_db').strpath,
+        '--basedir=' + mysqld_path.join('usr').strpath,
+        '--datadir=' + data_dir.strpath,
+    ))
+    proc = Popen((
+        mysqld_path.join('usr', 'sbin', 'mysqld').strpath,
+        '--no-defaults',
+        '--skip-networking',
+        '--lc-messages-dir', mysqld_path.join('usr', 'share', 'mysql').strpath,
+        '--datadir', data_dir.strpath,
+        '--socket', socket.strpath,
+    ))
+
+    elapsed = 0
+    step = 0.1
+    while elapsed < MYSQL_TIMEOUT and not mysql_ready(socket):
+        elapsed += step
+        time.sleep(step)
+
+    try:
+        yield socket
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+def mysql_ready(socket):
+    try:
+        get_connection(socket)
+    except pymysql.err.OperationalError:
+        return False
+    else:
+        return True
+
+
+def get_connection(socket, **kwargs):
+    return pymysql.connect(
+        user='root',
+        password=None,
+        unix_socket=socket.strpath,
+        autocommit=True,
+        cursorclass=pymysql.cursors.DictCursor,
+        **kwargs
+    )
+
+
+@pytest.yield_fixture
+def mysql_connection(mysqld_path, mysqld_socket, request, tmpdir):
+    db_name = 'test_' + ''.join(random.choice(string.ascii_lowercase) for _ in range(20))
+    with get_connection(mysqld_socket) as c:
+        c.execute('CREATE DATABASE {};'.format(db_name))
+
+    mysql = Popen(
+        (
+            mysqld_path.join('usr', 'bin', 'mysql').strpath,
+            '-h', 'localhost',
+            '-u', 'root',
+            '--password=',
+            '--database', db_name,
+            '--socket', mysqld_socket.strpath,
+        ),
+        stdin=PIPE,
+    )
+    schema = pkg_resources.resource_string('ocflib.printing', 'ocfprinting.sql')
+    schema = schema.replace(  # pretty hacky...
+        b'GRANT SELECT ON `ocfprinting`.',
+        b'GRANT SELECT ON `' + db_name.encode('ascii') + b'`.',
+    )
+    mysql.communicate(schema)
+    assert mysql.wait() == 0
+
+    with get_connection(mysqld_socket, db=db_name) as c:
+        yield c


### PR DESCRIPTION
You can log in to mysql with anonymous (no password) to see the
`printed` view which forms the core of the accounting.

You can log in with the ocfprinting user (in passwords file) to see the
full jobs and refunds tables, plus some additional views.

The functions like get_quota work already (try accounts ckuehl, asdf,
hjkl, pubstaff, and some you make up to see how it handles non-existent
users).