### PR TITLE
[WIP] Fix refunds without jobs

### DIFF
--- a/ocflib/printing/ocfprinting.sql
+++ b/ocflib/printing/ocfprinting.sql
@@ -65,6 +65,17 @@ CREATE VIEW `printed_today` AS
     LEFT OUTER JOIN refunds_today
     ON jobs_today.user = refunds_today.user
     GROUP BY jobs_today.user
+
+    UNION
+
+    SELECT
+        refunds_today.user AS user,
+        COALESCE(jobs_today.pages, 0) - COALESCE(refunds_today.pages, 0) AS today
+    FROM jobs_today
+    RIGHT OUTER JOIN refunds_today
+    ON jobs_today.user = refunds_today.user
+    GROUP BY refunds_today.user
+
     ORDER BY user;
 
 DROP VIEW IF EXISTS jobs_semester;
@@ -90,6 +101,17 @@ CREATE VIEW `printed_semester` AS
     LEFT OUTER JOIN refunds_semester
     ON jobs_semester.user = refunds_semester.user
     GROUP BY jobs_semester.user
+
+    UNION
+
+    SELECT
+        refunds_semester.user AS user,
+        COALESCE(jobs_semester.pages, 0) - COALESCE(refunds_semester.pages, 0) AS semester
+    FROM jobs_semester
+    RIGHT OUTER JOIN refunds_semester
+    ON jobs_semester.user = refunds_semester.user
+    GROUP BY refunds_semester.user
+
     ORDER BY user;
 
 DROP VIEW IF EXISTS printed;

--- a/tests/printing/quota_test.py
+++ b/tests/printing/quota_test.py
@@ -209,24 +209,31 @@ def test_refunds_without_jobs(mysql_connection):
     """We should be able to calculate quotas correctly for a user with a refund
     but no jobs."""
     # a user with no jobs at all but a refund today
-    assert_quota(mysql_connection, 'nobody', 0, 0)
+    assert_quota(mysql_connection, 'ckuehl', 0, 0)
 
-    add_refund(mysql_connection, TEST_REFUND._replace(pages=10))
-    assert_quota(mysql_connection, 'nobody', 10, 10)
+    add_refund(mysql_connection, TEST_REFUND._replace(user='ckuehl', pages=10))
+    assert_quota(mysql_connection, 'ckuehl', 10, 10)
 
     # a user with no jobs today and a refund earlier in the semester
-    add_job(mysql_connection, TEST_JOB._replace(user='somebody', pages=5, time=YESTERDAY))
-    assert_quota(mysql_connection, 'somebody', 0, -5)
+    add_job(mysql_connection, TEST_JOB._replace(user='mattmcal', pages=5, time=YESTERDAY))
+    assert_quota(mysql_connection, 'mattmcal', 0, -5)
 
-    add_refund(mysql_connection, TEST_REFUND._replace(pages=10, time=YESTERDAY))
-    assert_quota(mysql_connection, 'somebody', 0, 5)
+    add_refund(mysql_connection, TEST_REFUND._replace(user='mattmcal', pages=10, time=YESTERDAY))
+    assert_quota(mysql_connection, 'mattmcal', 0, 5)
 
     # a user with no jobs today and a refund today
-    add_job(mysql_connection, TEST_JOB._replace(user='yobody', pages=5, time=YESTERDAY))
-    assert_quota(mysql_connection, 'yobody', 0, -5)
+    add_job(mysql_connection, TEST_JOB._replace(user='jvperrin', pages=5, time=YESTERDAY))
+    assert_quota(mysql_connection, 'jvperrin', 0, -5)
 
-    add_refund(mysql_connection, TEST_REFUND._replace(pages=10))
-    assert_quota(mysql_connection, 'yobody', 10, 5)
+    add_refund(mysql_connection, TEST_REFUND._replace(user='jvperrin', pages=10))
+    assert_quota(mysql_connection, 'jvperrin', 10, 5)
+
+    # a user with just one job (today) but a refund earlier in the semester
+    add_job(mysql_connection, TEST_JOB._replace(user='kpengboy', pages=5))
+    assert_quota(mysql_connection, 'kpengboy', -5, -5)
+
+    add_refund(mysql_connection, TEST_REFUND._replace(user='kpengboy', pages=10, time=YESTERDAY))
+    assert_quota(mysql_connection, 'kpengboy', -5, 5)
 
 
 def test_jobs_and_refunds_today(mysql_connection):

--- a/tests/printing/quota_test.py
+++ b/tests/printing/quota_test.py
@@ -205,6 +205,30 @@ def test_get_quota_user_not_printed_today(mysql_connection):
     assert_quota(mysql_connection, 'ckuehl', 0, 0)
 
 
+def test_refunds_without_jobs(mysql_connection):
+    """We should be able to calculate quotas correctly for a user with a refund
+    but no jobs."""
+    # a user with no jobs at all but a refund today
+    assert_quota(mysql_connection, 'nobody', 0, 0)
+
+    add_refund(mysql_connection, TEST_REFUND._replace(pages=10))
+    assert_quota(mysql_connection, 'nobody', 10, 10)
+
+    # a user with no jobs today and a refund earlier in the semester
+    add_job(mysql_connection, TEST_JOB._replace(user='somebody', pages=5, time=YESTERDAY))
+    assert_quota(mysql_connection, 'somebody', 0, -5)
+
+    add_refund(mysql_connection, TEST_REFUND._replace(pages=10, time=YESTERDAY))
+    assert_quota(mysql_connection, 'somebody', 0, 5)
+
+    # a user with no jobs today and a refund today
+    add_job(mysql_connection, TEST_JOB._replace(user='yobody', pages=5, time=YESTERDAY))
+    assert_quota(mysql_connection, 'yobody', 0, -5)
+
+    add_refund(mysql_connection, TEST_REFUND._replace(pages=10))
+    assert_quota(mysql_connection, 'yobody', 10, 5)
+
+
 def test_jobs_and_refunds_today(mysql_connection):
     """Refunds should add back pages correctly."""
     assert_quota(mysql_connection, 'mattmcal', 0, 0)


### PR DESCRIPTION
Right now because of the way the join works, we don't include refunds for users who have never printed in our calculations.

Here's a (currently failing) test for that. If we can get it to pass we should be able to consider this fixed and merge this test plus the fix.