### PR TITLE
Switch back to VeryFascistCheck

### DIFF
--- a/ocflib/account/validators.py
+++ b/ocflib/account/validators.py
@@ -41,7 +41,7 @@ def validate_password(username, password, strength_check=True):
             raise ValueError('Password is too similar to username')
 
         try:
-            cracklib.FascistCheck(password)
+            cracklib.VeryFascistCheck(password)
         except ValueError as e:
             raise ValueError('Password problem: {}'.format(e))
 


### PR DESCRIPTION
Originally I checked passwords with VeryFascistCheck, which adds
some basic checks in Python to FascistCheck. Let's switch back,
at least until we switch to a pure Python implementation.

Currently we use the default wordlist, see `man update-cracklib`,
which is generated from /usr/share/dict/* in cron.daily.
Later we should probably use a real corpus of known passwords.