### PR TITLE
Add functions to modify LDAP attributes

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -45,10 +45,7 @@ def create_account(request, creds, report_status):
     with report_status('Finding', 'Found', 'first available UID'):
         new_uid = _get_first_available_uid()
 
-    dn = 'uid={user},{base_people}'.format(
-        user=request.user_name,
-        base_people=constants.OCF_LDAP_PEOPLE,
-    )
+    dn = utils.dn_for_username(request.user_name)
     attrs = {
         'objectClass': ['ocfAccount', 'account', 'posixAccount'],
         'cn': [request.real_name],

--- a/ocflib/account/utils.py
+++ b/ocflib/account/utils.py
@@ -146,3 +146,10 @@ def list_staff(group='ocfstaff'):
     :param group: UNIX group to use to determine if someone is a staff member.
     """
     return grp.getgrnam(group).gr_mem
+
+
+def dn_for_username(username):
+    return 'uid={user},{base_people}'.format(
+        user=username,
+        base_people=constants.OCF_LDAP_PEOPLE,
+    )

--- a/ocflib/misc/validators.py
+++ b/ocflib/misc/validators.py
@@ -39,3 +39,27 @@ def valid_email(email):
         except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
             pass
     return False
+
+
+# Pulled from /etc/shells on tsunami
+VALID_LOGIN_SHELLS = frozenset({
+    '/bin/sh',
+    '/bin/dash',
+    '/bin/bash',
+    '/bin/rbash',
+    '/usr/bin/screen',
+    '/usr/bin/tmux',
+    '/bin/zsh',
+    '/bin/tcsh',
+})
+
+# Separate the duplicates so we can list the above to users
+VALID_LOGIN_SHELLS_ALTPATHS = frozenset({
+    '/usr/bin/zsh',
+    '/usr/bin/tcsh',
+})
+
+
+def valid_login_shell(shell):
+    """Test that a file path is an actual valid login shell on tsunami."""
+    return shell in (VALID_LOGIN_SHELLS | VALID_LOGIN_SHELLS_ALTPATHS)

--- a/tests/account/submission_test.py
+++ b/tests/account/submission_test.py
@@ -309,3 +309,14 @@ def test_change_password(tasks, fake_credentials):
             keytab=fake_credentials.kerberos_keytab,
             comment='comment',
         )
+
+
+def test_modify_ldap_attributes(tasks, fake_credentials):
+    with mock.patch('ocflib.account.submission.real_modify_ldap_attributes') as m:
+        tasks.modify_ldap_attributes('ggroup', {'a': ['b', 'c'], 'd': ['e']})
+        m.assert_called_once_with(
+            username='ggroup',
+            attributes={'a': ['b', 'c'], 'd': ['e']},
+            keytab=fake_credentials.kerberos_keytab,
+            principal=fake_credentials.kerberos_principal,
+        )

--- a/tests/account/utils_test.py
+++ b/tests/account/utils_test.py
@@ -2,6 +2,7 @@ import mock
 import pexpect
 import pytest
 
+from ocflib.account.utils import dn_for_username
 from ocflib.account.utils import extract_username_from_principal
 from ocflib.account.utils import get_vhost_db
 from ocflib.account.utils import get_vhosts
@@ -233,3 +234,8 @@ def test_list_staff():
     assert 'ckuehl' in staff
     assert 'bpreview' not in staff
     assert 5 <= len(staff) <= 50
+
+
+def test_dn_for_username():
+    assert (dn_for_username('kpengboy') ==
+            'uid=kpengboy,ou=People,dc=OCF,dc=Berkeley,dc=EDU')

--- a/tests/misc/validators_test.py
+++ b/tests/misc/validators_test.py
@@ -3,6 +3,7 @@ import pytest
 from ocflib.misc.validators import email_host_exists
 from ocflib.misc.validators import host_exists
 from ocflib.misc.validators import valid_email
+from ocflib.misc.validators import valid_login_shell
 
 
 REAL_HOSTS = [
@@ -60,3 +61,19 @@ def test_email_host_exists(email, exists):
 ])
 def test_valid_email(email, valid):
     assert valid_email(email) == valid
+
+
+@pytest.mark.parametrize('shell,valid', [
+    ('/bin/sh', True),
+    ('/bin/bash', True),
+    ('/bin/dash', True),
+    ('/bin/trash', False),
+    ('/bin/rbash', True),
+    ('/bin/tcsh', True),
+    ('/bin/zsh', True),
+    ('/usr/bin/screen', True),
+    ('/usr/bin/tmux', True),
+    ('bash', False),
+])
+def test_valid_login_shell(shell, valid):
+    assert valid_login_shell(shell) == valid


### PR DESCRIPTION
In particular, add a celery task.

~~At the moment, it fails its most useful function in that it won't work properly with the mail attribute which requires a privileged bind to read. This will probably have to be solved by scraping the output of `ldapsearch`.~~

~~It also may be confusing for `create_ldap_entry_with_keytab` to also modify LDAP entries now.~~