### PR TITLE
Allow import when LDAP is down

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -462,7 +462,9 @@ class NewAccountRequest(namedtuple('NewAccountRequest', [
 
 
 # We use a module-level dict to "cache" across function calls.
-# TODO: This prevents importing this module when LDAP is unavailable.
-# https://github.com/ocf/ocfweb/issues/103
-_cache = {'known_uid': 37500}
-_get_first_available_uid()
+_cache = {'known_uid': 43000}
+try:
+    _get_first_available_uid()
+except Exception:
+    # Don't break import (and ocfweb) if LDAP is down.
+    pass


### PR DESCRIPTION
While we could use some more complicated logic or warn when `_get_first_available_uid` is broken, likely because LDAP is down, for simplicity we just pass and handle errors later during account creation.