### PR TITLE
Don't pin ldap3 so strictly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'cracklib',
         'dnspython3',
         'jinja2',
-        'ldap3==1.4.0',
+        'ldap3<=1.999',
         'paramiko',
         'pexpect',
         'pycrypto',


### PR DESCRIPTION
In packages, we want to pin as loosely as possible to allow applications more freedom. In this case, I think we just want to stay off the 2.x series for now.

In particular we weren't satisfying this in system site-packages.