### PR TITLE
Bump ldap3 to version 2

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -46,7 +46,7 @@ def _get_first_available_uid(known_uid=_KNOWN_UID):
             '(uidNumber>={KNOWN_MIN})'.format(KNOWN_MIN=known_uid),
             attributes=['uidNumber'],
         )
-        uids = [int(entry['attributes']['uidNumber'][0]) for entry in c.response]
+        uids = [int(entry['attributes']['uidNumber']) for entry in c.response]
     if uids:
         max_uid = max(uids)
     else:
@@ -92,18 +92,18 @@ def create_account(request, creds, report_status, known_uid=_KNOWN_UID):
         attrs = {
             'objectClass': ['ocfAccount', 'account', 'posixAccount'],
             'cn': [request.real_name],
-            'uidNumber': [str(new_uid)],
-            'gidNumber': [str(getgrnam('ocf').gr_gid)],
-            'homeDirectory': [utils.home_dir(request.user_name)],
-            'loginShell': ['/bin/bash'],
+            'uidNumber': new_uid,
+            'gidNumber': getgrnam('ocf').gr_gid,
+            'homeDirectory': utils.home_dir(request.user_name),
+            'loginShell': '/bin/bash',
             'mail': [request.email],
-            'userPassword': ['{SASL}' + request.user_name + '@OCF.BERKELEY.EDU'],
-            'creationTime': [datetime.now().strftime('%Y%m%d%H%M%SZ')],
+            'userPassword': '{SASL}' + request.user_name + '@OCF.BERKELEY.EDU',
+            'creationTime': datetime.now(),
         }
         if request.calnet_uid:
-            attrs['calnetUid'] = [str(request.calnet_uid)]
+            attrs['calnetUid'] = request.calnet_uid
         else:
-            attrs['callinkOid'] = [str(request.callink_oid)]
+            attrs['callinkOid'] = request.callink_oid
 
         with report_status('Creating', 'Created', 'LDAP entry'):
             create_ldap_entry_with_keytab(

--- a/ocflib/account/search.py
+++ b/ocflib/account/search.py
@@ -59,7 +59,7 @@ def user_exists(account):
 
 
 def user_is_sorried(account):
-    shell, = user_attrs(account)['loginShell']
+    shell = user_attrs(account)['loginShell']
     return shell == constants.SORRIED_SHELL
 
 

--- a/ocflib/infra/hosts.py
+++ b/ocflib/infra/hosts.py
@@ -42,4 +42,4 @@ def type_of_host(hostname):
     'server'
     """
     hosts = hosts_by_filter('(cn={})'.format(hostname))
-    return hosts[0]['type'][0] if hosts else None
+    return hosts[0]['type'] if hosts else None

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'cracklib',
         'dnspython3',
         'jinja2',
-        'ldap3<=1.999',
+        'ldap3',
         'paramiko',
         'pexpect',
         'pycrypto',

--- a/tests-manual/infra/create-ldap-keytab
+++ b/tests-manual/infra/create-ldap-keytab
@@ -1,19 +1,24 @@
 #!/usr/bin/env python3
+from datetime import datetime
+
 from ocflib.infra.ldap import create_ldap_entry_with_keytab
 
 
+# Run with:
+#   sudo -u create /path/to/ocflib/venv/bin/python3 create-ldap-keytab
 if __name__ == '__main__':
     create_ldap_entry_with_keytab(
         'uid=ggroup2,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
         {
             'objectClass': ['ocfAccount', 'account', 'posixAccount'],
-            'uidNumber': ['99999999'],
-            'homeDirectory': ['/dev/null'],
-            'loginShell': ['/bin/zsh'],
+            'uidNumber': 99999999,
+            'homeDirectory': '/dev/null',
+            'loginShell': '/bin/zsh',
             'cn': ['Some Test Account That Should Be Deleted'],
-            'calnetUid': ['1034192'],
-            'gidNumber': ['1000'],
+            'calnetUid': 1034192,
+            'gidNumber': 1000,
+            'creationTime': datetime.now(),
         },
-        '/home/c/ck/ckuehl/create.keytab',
+        '/etc/ocf-create/create.keytab',
         'create/admin',
     )

--- a/tests-manual/infra/get-krb-keytab
+++ b/tests-manual/infra/get-krb-keytab
@@ -3,7 +3,7 @@ from ocflib.infra.kerberos import get_kerberos_principal_with_keytab
 
 
 # Run with:
-#   sudo -u create /path/to/ocflib/venv/bin/python3 get-krb-keytab.py
+#   sudo -u create /path/to/ocflib/venv/bin/python3 get-krb-keytab
 if __name__ == '__main__':
     assert get_kerberos_principal_with_keytab(
         'mattmcal',

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import datetime
 from textwrap import dedent
 
 import mock
@@ -85,9 +86,9 @@ class TestFirstAvailableUID:
 
     def test_first_uid(self):
         connection = mock.Mock(response=[
-            {'attributes': {'uidNumber': [999000]}},
-            {'attributes': {'uidNumber': [999200]}},
-            {'attributes': {'uidNumber': [999100]}},
+            {'attributes': {'uidNumber': 999000}},
+            {'attributes': {'uidNumber': 999200}},
+            {'attributes': {'uidNumber': 999100}},
         ])
 
         @contextmanager
@@ -519,8 +520,8 @@ class TestValidateRequest:
 class TestCreateAccount:
 
     @pytest.mark.parametrize('is_group,calnet_uid,callink_oid,expected', [
-        (False, 123456, None, {'calnetUid': ['123456']}),
-        (True, None, 123456, {'callinkOid': ['123456']}),
+        (False, 123456, None, {'calnetUid': 123456}),
+        (True, None, 123456, {'callinkOid': 123456}),
     ])
     def test_create(
         self,
@@ -570,14 +571,14 @@ class TestCreateAccount:
                 'uid=someuser,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
                 dict({
                     'cn': ['Some User'],
-                    'gidNumber': ['1000'],
+                    'gidNumber': 1000,
                     'objectClass': ['ocfAccount', 'account', 'posixAccount'],
-                    'uidNumber': ['42'],
-                    'homeDirectory': ['/home/s/so/someuser'],
-                    'loginShell': ['/bin/bash'],
+                    'uidNumber': 42,
+                    'homeDirectory': '/home/s/so/someuser',
+                    'loginShell': '/bin/bash',
                     'mail': ['some.user@ocf.berkeley.edu'],
-                    'userPassword': ['{SASL}someuser@OCF.BERKELEY.EDU'],
-                    'creationTime': ['20150822141144Z'],
+                    'userPassword': '{SASL}someuser@OCF.BERKELEY.EDU',
+                    'creationTime': datetime.now(),
                 }, **expected),
                 fake_credentials.kerberos_keytab,
                 fake_credentials.kerberos_principal,

--- a/tests/account/search_test.py
+++ b/tests/account/search_test.py
@@ -1,4 +1,5 @@
 import pytest
+from ldap3.core.exceptions import LDAPAttributeError
 
 from ocflib.account.search import user_attrs
 from ocflib.account.search import user_attrs_ucb
@@ -17,7 +18,6 @@ class TestUsersByFilter:
         ('(uidNumber=28460)', {'ckuehl'}),
         ('(|(uidNumber=28460)(uid=daradib))', {'ckuehl', 'daradib'}),
         ('(uid=doesnotexist)', set()),
-        ('(herp=derp)', set()),
         ('(!(uid=*))', set()),
     ])
     def test_users_by_filter(self, filter_str, results):
@@ -26,6 +26,10 @@ class TestUsersByFilter:
     @pytest.mark.parametrize('filter_str', ['', 'uid=ckuehl', '42', 'asdf'])
     def test_invalid_filters(self, filter_str):
         with pytest.raises(Exception):
+            users_by_filter(filter_str)
+
+    def test_invalid_ldap_attr(self, filter_str='(herp=derp)'):
+        with pytest.raises(LDAPAttributeError):
             users_by_filter(filter_str)
 
 
@@ -50,7 +54,7 @@ class TestUserAttrs:
     def test_existing_user(self):
         user = user_attrs('ckuehl')
         assert user['uid'] == ['ckuehl']
-        assert user['uidNumber'] == ['28460']
+        assert user['uidNumber'] == 28460
 
     def test_nonexistent_user(self):
         assert user_attrs('doesnotexist') is None

--- a/tests/infra/hosts_test.py
+++ b/tests/infra/hosts_test.py
@@ -1,4 +1,5 @@
 import pytest
+from ldap3.core.exceptions import LDAPAttributeError
 
 from ocflib.infra.hosts import hostname_from_domain
 from ocflib.infra.hosts import hosts_by_filter
@@ -13,7 +14,6 @@ class TestHostsByFilter:
     @pytest.mark.parametrize('filter_str,expected', [
         ('(cn=death)', ['death']),
         ('(cn=doesnotexist)', []),
-        ('(herp=derp)', []),
     ])
     def test_hosts_by_filter(self, filter_str, expected):
         results = self._hostnames(hosts_by_filter(filter_str))
@@ -22,6 +22,10 @@ class TestHostsByFilter:
     @pytest.mark.parametrize('filter_str', ['', 'cn=death', '42', 'asdf'])
     def test_invalid_filters(self, filter_str):
         with pytest.raises(Exception):
+            hosts_by_filter(filter_str)
+
+    def test_invalid_ldap_attr(self, filter_str='(herp=derp)'):
+        with pytest.raises(LDAPAttributeError):
             hosts_by_filter(filter_str)
 
     def test_puppet_class(self):

--- a/tests/infra/ldap_test.py
+++ b/tests/infra/ldap_test.py
@@ -1,4 +1,5 @@
 from base64 import b64encode
+from datetime import datetime
 
 import mock
 import pytest
@@ -32,7 +33,7 @@ class TestCreateLdapEntry:
         mock_spawn.return_value.before = b'\n'
         create_ldap_entry_with_keytab(
             'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
-            {'a': ['b', 'c'], 'd': ['e']},
+            {'a': ['b', 'c'], 'd': 12, 'e': datetime(2016, 11, 5, 12, 0, 0)},
             '/nonexist',
             'create/admin',
         )
@@ -52,7 +53,8 @@ class TestCreateLdapEntry:
                 ('dn', 'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU'),
                 ('a', 'b'),
                 ('a', 'c'),
-                ('d', 'e'),
+                ('d', '12'),
+                ('e', '20161105120000Z'),
             ]
         ] + [mock.call('changetype: add')], any_order=True)
         assert mock_spawn.return_value.sendeof.called
@@ -87,7 +89,7 @@ class TestModifyLdapEntry:
         mock_spawn.return_value.before = b'\n'
         modify_ldap_entry_with_keytab(
             'uid=mattmcal,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
-            {'a': ['b', 'c'], 'calnetUid': ['1234']},
+            {'a': ['b', 'c'], 'calnetUid': 1234},
             '/nonexist',
             'create/admin'
         )


### PR DESCRIPTION
ldap3 now distinguishes between single- and multi-valued attributes and
converts attributes to python data types, which requires several internal
changes.

Basically, instead of getting
```python
{
   'cn': ['Matthew McAllister'],
   'loginShell': ['/bin/bash'],
   'uidNumber': ['28108'],
   'homeDirectory': ['/home/m/ma/mattmcal'],
   'gidNumber': ['1000'],
   'objectClass': ['ocfAccount', 'account', 'posixAccount'],
   'creationTime': ['20130909235546Z'],
   'uid': ['mattmcal'],
   'calnetUid': ['1031366']
}
```
you get
```python
{
    'cn': ['Matthew McAllister'], 
    'loginShell': '/bin/bash',
    'uidNumber': 28108,
    'homeDirectory': '/home/m/ma/mattmcal',
    'gidNumber': 1000
    'objectClass': ['ocfAccount', 'account', 'posixAccount'],
    'creationTime': datetime.datetime(2013, 9, 9, 23, 55, 46, tzinfo=OffsetTzInfo(offset=0, name='UTC')),
    'uid': ['mattmcal'],
    'calnetUid': 1031366,
}
```
This change makes ocflib handle LDAP attributes internally as python data types instead of strings and adjusts for the fact that single-valued attributes are no longer wrapped in a list. I don't think  we have any other code that directly handles LDAP attributes at the moment, so nothing else should have to change.

What's awkward about this is that we make changes to LDAP by writing an LDIF, so currently ocflib still has to convert to strings at write time. If we ever figure out how to authenticate using the ldap3 package, though, it will be good for ensuring code is consistent with the LDAP schema. Also, apparently the University's LDAP schema is such that everything is still a list of strings, so code reading from that didn't really change.