### PR TITLE
Bugfix and tests for ucb.directory

### DIFF
--- a/ocflib/ucb/directory.py
+++ b/ocflib/ucb/directory.py
@@ -34,7 +34,7 @@ def name_by_calnet_uid(uid):
         if given_name and sn:
             return '{} {}'.format(given_name, sn)
     else:
-        return names.get('displayName', None)
+        return names.get('displayName')
 
 
 def calnet_uids_by_name(name):

--- a/ocflib/ucb/directory.py
+++ b/ocflib/ucb/directory.py
@@ -33,11 +33,8 @@ def name_by_calnet_uid(uid):
 
         if given_name and sn:
             return '{} {}'.format(given_name, sn)
-    elif 'displayName' in names:
-        display_name = get_longest_string(names['displayName'])
-
-        if display_name:
-            return display_name
+    else:
+        return names.get('displayName', None)
 
 
 def calnet_uids_by_name(name):

--- a/ocflib/ucb/groups.py
+++ b/ocflib/ucb/groups.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree
 import requests
 
 import ocflib.account.search as search
+from ocflib.ucb.directory import name_by_calnet_uid
 
 
 _API = {
@@ -103,13 +104,7 @@ def signatories_for_group(oid):
     def parser(root):
         def parse(student):
             uid = int(student.findtext('Username'))
-
-            attrs = search.user_attrs_ucb(uid)
-            name = None
-
-            if attrs:
-                name = attrs.get('displayName', [None])[0]
-
+            name = name_by_calnet_uid(uid)
             users = search.users_by_calnet_uid(uid)
             return uid, {'name': name, 'accounts': users}
 

--- a/tests/account/search_test.py
+++ b/tests/account/search_test.py
@@ -9,6 +9,7 @@ from ocflib.account.search import user_is_sorried
 from ocflib.account.search import users_by_callink_oid
 from ocflib.account.search import users_by_calnet_uid
 from ocflib.account.search import users_by_filter
+from tests.conftest import TEST_PERSON_CALNET_UID
 
 
 class TestUsersByFilter:
@@ -62,10 +63,7 @@ class TestUserAttrs:
 
 class TestUserAttrsUCB:
 
-    def test_existing_user(self, test_uid=1101587):
-        """These are a little flaky because alumni eventually get kicked out of
-        the university's "People" OU. So you'll need to update these every few
-        years."""
+    def test_existing_user(self, test_uid=TEST_PERSON_CALNET_UID):
         user = user_attrs_ucb(test_uid)
         assert user['uid'] == [str(test_uid)]
         assert 'person' in user['objectClass']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,15 @@ import pymysql
 import pytest
 
 
+# To test functions that query UCB LDAP for people, we simply pick
+# someone who has a few years before graduating and use their name and
+# CalNet UID. Alumni eventually get kicked out of the university's
+# "People" OU, so these constants have to be updated every few years
+# after the aforementioned party has graduated.
+TEST_PERSON_CALNET_UID = 1101587
+TEST_PERSON_NAME = 'Jason Perrin'
+
+
 MYSQL_TIMEOUT = 10
 
 

--- a/tests/ucb/directory_test.py
+++ b/tests/ucb/directory_test.py
@@ -1,0 +1,41 @@
+import mock
+import pytest
+
+from ocflib.ucb.directory import calnet_uids_by_name
+from ocflib.ucb.directory import name_by_calnet_uid
+from tests.conftest import TEST_PERSON_CALNET_UID
+from tests.conftest import TEST_PERSON_NAME
+
+
+class TestNameByCalNetUID:
+
+    @pytest.mark.parametrize('attrs,expected', [
+        ({'givenName': ['Jason'], 'sn': ['Perrin']}, 'Jason Perrin'),
+        ({'displayName': 'Matthew McAllister'}, 'Matthew McAllister'),
+        ({}, None),
+    ])
+    def test_name_by_calnet_uid(self, attrs, expected):
+        """This tests that the 'displayName' fallback works without hitting
+        UCB LDAP, since we can't actually control entries there."""
+        with mock.patch(
+            'ocflib.account.search.user_attrs_ucb',
+            return_value=attrs
+        ):
+            assert name_by_calnet_uid(0) == expected
+
+    @pytest.mark.parametrize('uid,expected', [
+        (TEST_PERSON_CALNET_UID, TEST_PERSON_NAME),
+        (9999999, None),
+    ])
+    def test_name_by_calnet_uid_real_query(self, uid, expected):
+        assert name_by_calnet_uid(uid) == expected
+
+
+class TestCalNetUIDsByName:
+
+    @pytest.mark.parametrize('name,expected', [
+        (TEST_PERSON_NAME, [TEST_PERSON_CALNET_UID]),
+        ('~~~', []),
+    ])
+    def test_calnet_uids_by_name(self, name, expected):
+        assert calnet_uids_by_name(name) == expected


### PR DESCRIPTION
This corrects `signatories_for_group` to get names using `name_by_calnet_uid`, fixing a bug with the new version of ldap3, and adds tests for the functions in `ucb.directory`.

I would like to test `ucb.groups` as well, but those will likely be flakier if we want to actually query CalLink.