### PR TITLE
Don't package our tests; don't max-version sqlalchemy

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,2 +1,3 @@
 ldap3 python3-ldap3
 pymysql python3-pymysql
+sqlalchemy python3-sqlalchemy

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email='help@ocf.berkeley.edu',
     description='libraries for account and server management',
     url='https://www.ocf.berkeley.edu',
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests*',)),
     package_data={
         'ocflib.account': ['mail_templates/*'],
         'ocflib.printing': ['ocfprinting.schema'],


### PR DESCRIPTION
Afterwards the dependencies look like:

```
 Depends: python3-cached-property, python3-cracklib, python3-crypto, python3-dnspython, python3-jinja2, python3-ldap3, python3-paramiko, python3-pexpect, python3-pymysql, python3-pysnmp4, python3-redis, python3-requests, python3-sqlalchemy, python3-yaml, python3:any (>= 3.3.2-2~)
```