### PR TITLE
Update hours; start at Berkeley time

### DIFF
--- a/ocflib/lab/hours.py
+++ b/ocflib/lab/hours.py
@@ -83,14 +83,14 @@ class Day(namedtuple('Day', ['date', 'weekday', 'holiday', 'hours'])):
         return not self.hours
 
 
-REGULAR_HOURS = defaultdict(lambda: [Hour(time(9), time(19))], {
-    Day.MONDAY: [Hour(time(9), time(18))],
-    Day.TUESDAY: [Hour(time(11), time(19))],
-    Day.WEDNESDAY: [Hour(time(9), time(17)), Hour(time(18), time(19))],
-    Day.THURSDAY: [Hour(time(11), time(15)), Hour(time(16), time(19))],
-    Day.FRIDAY: [Hour(time(9), time(18))],
-    Day.SATURDAY: [Hour(time(12), time(16))],
-    Day.SUNDAY: [Hour(time(12), time(16))],
+REGULAR_HOURS = defaultdict(lambda: [Hour(time(9, 10), time(19))], {
+    Day.MONDAY: [Hour(time(10, 10), time(11)), Hour(time(14, 10), time(18))],
+    Day.TUESDAY: [Hour(time(11, 10), time(19))],
+    Day.WEDNESDAY: [Hour(time(10, 10), time(17)), Hour(time(18, 10), time(19))],
+    Day.THURSDAY: [Hour(time(11, 10), time(15)), Hour(time(16, 10), time(19))],
+    Day.FRIDAY: [Hour(time(9, 10), time(11)), Hour(time(14, 10), time(18))],
+    Day.SATURDAY: [Hour(time(12, 10), time(16))],
+    Day.SUNDAY: [Hour(time(12, 10), time(16))],
 })
 
 HOLIDAYS = [


### PR DESCRIPTION
In addition to showing off our newly crummy hours (which don't take effect for over a week), this changes all hours to start at Berkeley time instead of on the hour.

There is unfortunately a nontrivial failure to communicate this information, even though it is posted outside our door and on our hours page. The fact is, most reasonable people just look at the hours listing and assume they are exact; thus, our hours listings come off as rather misinformative, and some people are quite dismayed when they find themselves waiting ten minutes or more to get into the lab (especially when they're trying to print ten minutes before class...).

Although it comes at the cost of making our website a bit uglier, I think the more detailed listing will prevent a lot of confusion, and people will appreciate the more accurate information.