### PR TITLE
Add vhost.config for generating server configs

### DIFF
--- a/ocflib/vhost/application.py
+++ b/ocflib/vhost/application.py
@@ -1,3 +1,5 @@
+import re
+
 import requests
 
 VHOST_DB_PATH = '/home/s/st/staff/vhost/vhost-app.conf'
@@ -19,15 +21,16 @@ def get_app_vhosts():
     """Returns a list of application virtual hosts in convenient format.
 
     >>> get_app_vhosts()
-    ...
     {
+    ...
         'ml.berkeley.edu': {
             'username': 'mlab',
-            'socket_name': 'mlab'
-            'ssl_cert': 'ml.berkeley.edu',
+            'socket': 'mlab'
+            'aliases': [],
+            'flags': []
         }
-    }
     ...
+    }
     """
     def fully_qualify(host):
         """Fully qualifies a hostname (by appending .berkeley.edu) if it's not
@@ -42,12 +45,18 @@ def get_app_vhosts():
 
         fields = line.split(' ')
 
-        username, host, socket, ssl_cert = fields
+        if len(fields) < 5:
+            flags = []
+        else:
+            flags = re.search('^\[(.*)\]$', fields[4]).group(1).split(',')
+
+        username, host, socket, aliases = fields[:4]
 
         vhosts[fully_qualify(username if host == '-' else host)] = {
             'username': username,
             'socket': socket if socket != '-' else username,
-            'ssl_cert': ssl_cert if ssl_cert != '-' else None,
+            'aliases': aliases.split(',') if aliases != '-' else [],
+            'flags': flags,
         }
 
     return vhosts

--- a/ocflib/vhost/config.py
+++ b/ocflib/vhost/config.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+import os
+from collections import namedtuple
+from pathlib import Path
+
+import jinja2
+
+from ocflib.account.search import user_is_sorried
+from ocflib.misc.mail import email_for_user
+from ocflib.vhost.application import get_app_vhosts
+from ocflib.vhost.web import get_vhosts
+
+
+SITE_CFG = '/etc/nginx/sites-enabled/virtual'
+
+LETS_ENCRYPT_SSL = Path('/services/http/ssl')
+SSL_BUNDLE = Path('/etc/ssl/apphost')
+
+APP_DIR = Path('/srv/apps')
+WEB_DIR = Path('/services/http/users')
+
+jinja_env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader((
+        os.path.abspath(os.path.dirname(__file__)),
+    )),
+)
+
+
+class VirtualHost(namedtuple('VirtualHost', (
+    'fqdn',
+    'user',
+    'socket_or_docroot',
+    'aliases',
+    'flags',
+))):
+    """A single virtual host as defined by the vhost config files.
+
+    This class defines lots of helper functions which are used in
+    generating vhost configuration on the web and app hosts.
+
+    The web and application vhost configs differ only in specifying
+    either a socket name or directory to serve. Hence, the two are
+    aliased into a single variable whose meaning is differentiated by
+    the method used to access it.
+    """
+    @property
+    def socket(self):
+        return str(APP_DIR / self.user / (self.socket_or_docroot + '.sock'))
+
+    @property
+    def socket_dir(self):
+        return str(APP_DIR / self.user)
+
+    @property
+    def docroot(self):
+        return str(WEB_DIR / self.user[0] / self.user)
+
+    @property
+    def contact_email(self):
+        return email_for_user(self.user)
+
+    @property
+    def dev_alias(self):
+        return self.fqdn.replace('.', '-') + '.apphost.ocf.berkeley.edu'
+
+    @property
+    def disabled(self):
+        return user_is_sorried(self.user)
+
+    @property
+    def use_ssl(self):
+        return 'nossl' not in self.flags
+
+    @property
+    def port(self):
+        return 443 if self.use_ssl else 80
+
+    @property
+    def ssl_key(self):
+        return '/etc/ssl/lets-encrypt/le-vhost.key'
+
+    @property
+    def ssl_cert(self):
+        return str(LETS_ENCRYPT_SSL / (self.fqdn + '.crt'))
+
+    @property
+    def ssl_chain(self):
+        return '/etc/ssl/certs/lets-encrypt.crt'
+
+    @property
+    def ssl_bundle(self):
+        return str(SSL_BUNDLE / (self.fqdn + '.crt'))
+
+
+def build_web_config():
+    """Generates an apache config file for web vhosts from the config
+    file."""
+    vhosts = set()
+    for domain, vhost in get_vhosts().items():
+        vhosts.add(VirtualHost(
+            fqdn=domain,
+            user=vhost['username'],
+            socket_or_docroot=vhost['docroot'],
+            aliases=tuple(vhost['aliases']),
+            flags=tuple(vhost['flags']),
+        ))
+    tmpl = jinja_env.get_template('vhost-web.jinja')
+    return '\n\n'.join(
+        tmpl.render(vhost=vhost)
+        for vhost in sorted(
+            vhosts,
+            key=lambda vhost: (vhost.user, vhost.fqdn),
+        )
+    )
+
+
+def build_app_config():
+    """Generates an nginx config file for app vhosts from the config
+    file."""
+    vhosts = set()
+    for domain, vhost in get_app_vhosts().items():
+        vhosts.add(VirtualHost(
+            fqdn=domain,
+            user=vhost['username'],
+            socket_or_docroot=vhost['socket'],
+            aliases=tuple(vhost['aliases']),
+            flags=tuple(vhost['flags']),
+        ))
+    tmpl = jinja_env.get_template('vhost-app.jinja')
+    return '\n\n'.join(
+        tmpl.render(vhost=vhost)
+        for vhost in sorted(
+            vhosts,
+            key=lambda vhost: (vhost.user, vhost.fqdn),
+        )
+    )

--- a/ocflib/vhost/vhost-app.jinja
+++ b/ocflib/vhost/vhost-app.jinja
@@ -1,0 +1,51 @@
+# {{vhost.fqdn}} (user {{vhost.user}})
+server {
+    listen {{vhost.port}};
+    listen [::]:{{vhost.port}};
+    server_name "{{vhost.fqdn}}" "{{vhost.dev_alias}}"
+        {%- for alias in vhost.aliases %} "{{alias}}"{% endfor %};
+
+    location /.well-known/ {
+        proxy_pass https://www.ocf.berkeley.edu/.well-known/;
+    }
+
+    location / {
+        {% if vhost.disabled %}
+            # Proxy to the "unavailable" site, just as regular vhosts do.
+            proxy_pass https://unavailable.ocf.berkeley.edu/;
+            proxy_set_header Host unavailable.ocf.berkeley.edu;
+        {% else %}
+            proxy_pass http://unix:{{vhost.socket}};
+            proxy_set_header Host $host;
+        {% endif %}
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    access_log /var/log/nginx/vhost_access.log vhost;
+
+    {% if vhost.use_ssl %}
+        ssl on;
+        ssl_certificate {{vhost.ssl_bundle}};
+        ssl_certificate_key {{vhost.ssl_key}};
+        add_header Strict-Transport-Security "max-age=31536000";
+    {% endif %}
+}
+{% if vhost.use_ssl %}
+server {
+    listen 80;
+    listen [::]:80;
+    server_name "{{vhost.fqdn}}" "{{vhost.dev_alias}}"
+        {%- for alias in vhost.aliases %} "{{alias}}"{% endfor %};
+
+    # Proxy /.well-known/ to www.o.b.e/.well-known/ so death can request
+    # Let's Encrypt certificates for app vhosts
+    location /.well-known/ {
+        proxy_pass https://www.ocf.berkeley.edu/.well-known/;
+    }
+
+    return 301 https://$server_name$request_uri;
+
+    access_log /var/log/nginx/vhost_access.log vhost;
+}
+{% endif %}

--- a/ocflib/vhost/vhost-web.jinja
+++ b/ocflib/vhost/vhost-web.jinja
@@ -1,0 +1,83 @@
+# {{vhost.fqdn}} (user {{vhost.user}})
+<VirtualHost *:{{vhost.port}}>
+    ServerName {{vhost.fqdn}}
+    {% if vhost.aliases %}
+        ServerAlias {%- for alias in vhost.aliases %} {{alias}}{% endfor %}
+    {% endif %}
+    ServerAdmin {{vhost.contact_email}}
+    DocumentRoot {{vhost.docroot}}
+
+    {% if vhost.use_ssl %}
+        # SSL
+        SSLEngine on
+        SSLCertificateFile {{vhost.ssl_cert}}
+        SSLCertificateKeyFile {{vhost.ssl_key}}
+        SSLCertificateChainFile {{vhost.ssl_chain}}
+    {% endif %}
+
+    {% if vhost.disabled %}
+        # Proxy to the local "unavailable" vhost, which serves up a friendly
+        # "your website is rekt" page.
+        RequestHeader set Host unavailable.ocf.berkeley.edu
+        ProxyPass / http://localhost/
+    {% else %}
+        <Directory {{vhost.docroot}}>
+            Options ExecCGI IncludesNoExec Indexes MultiViews SymLinksIfOwnerMatch
+            AllowOverride All
+            Require all granted
+            DirectoryIndex index.html index.cgi index.pl index.php index.xhtml index.htm index.shtm index.shtml
+        </Directory>
+
+        <Directory /services/http/suexec>
+            Options +ExecCGI
+            AllowOverride None
+            Require all granted
+            SetHandler fastcgi-script
+        </Directory>
+
+        <FilesMatch "\.ph(p3?|tml)$">
+            Require all granted
+            SetHandler php5-fcgi
+        </FilesMatch>
+
+        Action php5-fcgi /php5-fcgi
+        Alias /php5-fcgi /services/http/suexec/php5-fcgi-wrapper
+        SuexecUserGroup {{vhost.user}} ocf
+    {% endif %}
+
+    Alias /.well-known /srv/well-known
+
+    ServerSignature Off
+
+    ErrorLog /var/log/apache2/vhost-error.log
+    CustomLog /var/log/apache2/vhost-access.log combined
+
+    UserDir disabled
+    suPHP_Engine off
+</VirtualHost>
+{% if vhost.use_ssl %}
+    <VirtualHost *:80>
+        ServerName {{vhost.fqdn}}
+        {% if vhost.aliases %}
+            ServerAlias {%- for alias in vhost.aliases %} {{alias}}{% endfor %}
+        {% endif %}
+        ServerAdmin {{vhost.contact_email}}
+        DocumentRoot {{vhost.docroot}}
+
+        RewriteEngine on
+        RewriteCond %{REQUEST_URI} !^/\.well-known/
+        # 301 redirects are more correct, but get cached forever by dumb browers.
+        # Doesn't matter too much for vhosts.
+        RewriteRule ^(.*)$ https://{{vhost.fqdn}}$1 [L,R=302]
+
+        Alias /.well-known /srv/well-known
+
+        ServerSignature Off
+
+        ErrorLog /var/log/apache2/vhost-error.log
+        CustomLog /var/log/apache2/vhost-access.log combined
+
+        UserDir disabled
+        suPHP_Engine off
+    </VirtualHost>
+{% endif %}

--- a/ocflib/vhost/web.py
+++ b/ocflib/vhost/web.py
@@ -30,7 +30,8 @@ def get_vhosts():
             'username': 'bpr',
             'aliases': ['bpr.berkeley.edu'],
             'docroot': '/',
-            'redirect': None  # format is '/ https://some.other.site/'
+            'flags': [],
+            'redirect': None,
         }
     }
     ...
@@ -55,12 +56,6 @@ def get_vhosts():
 
         username, host, aliases, docroot = fields[:4]
 
-        redirect = None
-
-        if username.endswith('!'):
-            username = username[:-1]
-            redirect = '/ https://www.ocf.berkeley.edu/~{}/'.format(username)
-
         if aliases != '-':
             aliases = list(map(fully_qualify, aliases.split(',')))
         else:
@@ -70,8 +65,8 @@ def get_vhosts():
             'username': username,
             'aliases': aliases,
             'docroot': '/' if docroot == '-' else docroot,
-            'redirect': redirect,
-            'flags': flags
+            'flags': flags,
+            'redirect': None,
         }
 
     return vhosts

--- a/tests/vhost/application_test.py
+++ b/tests/vhost/application_test.py
@@ -4,7 +4,7 @@ from ocflib.vhost.application import get_app_vhosts
 
 
 VHOSTS_EXAMPLE = """
-asucapp api.asuc.ocf.berkeley.edu prod api.asuc.ocf.berkeley.edu
+asucapp api.asuc.ocf.berkeley.edu prod api.asuc.org
 ggroup dev-app.ocf.berkeley.edu - -
 upe - - -
 """
@@ -12,18 +12,21 @@ upe - - -
 VHOSTS_EXAMPLE_PARSED = {
     'api.asuc.ocf.berkeley.edu': {
         'socket': 'prod',
-        'ssl_cert': 'api.asuc.ocf.berkeley.edu',
+        'aliases': ['api.asuc.org'],
         'username': 'asucapp',
+        'flags': [],
     },
     'dev-app.ocf.berkeley.edu': {
         'socket': 'ggroup',
-        'ssl_cert': None,
+        'aliases': [],
         'username': 'ggroup',
+        'flags': [],
     },
     'upe.berkeley.edu': {
         'socket': 'upe',
-        'ssl_cert': None,
+        'aliases': [],
         'username': 'upe',
+        'flags': [],
     },
 }
 
@@ -31,7 +34,7 @@ VHOSTS_EXAMPLE_PARSED = {
 class TestVirtualHosts:
 
     # The database-reading function is identical to that in vhost.web, so
-    # there's not much meaning in making tests slower by testing them.
+    # there's not much meaning in making tests slower by testing it.
 
     @mock.patch(
         'ocflib.vhost.application.get_app_vhost_db',

--- a/tests/vhost/config_test.py
+++ b/tests/vhost/config_test.py
@@ -1,0 +1,72 @@
+import re
+from textwrap import dedent
+
+import mock
+
+from .application_test import VHOSTS_EXAMPLE as VHOSTS_APP_EXAMPLE
+from .web_test import VHOSTS_EXAMPLE as VHOSTS_WEB_EXAMPLE
+from ocflib.vhost.config import build_app_config
+from ocflib.vhost.config import build_web_config
+
+
+class TestBuildConfig:
+    @mock.patch(
+        'ocflib.vhost.web.get_vhost_db',
+        return_value=VHOSTS_WEB_EXAMPLE.splitlines(),
+    )
+    def test_build_web_config(self, _):
+        config = build_web_config()
+
+        # Actually testing config files is hard, so just match some regexes
+        m = re.match(dedent("""\
+            # archive\.asuc\.org \(user asucarch\)
+            (.*)
+            # docs\.ocf\.berkeley\.edu \(user ocfwiki\)
+            (.*)
+            # contrib\.berkeley\.edu \(user staff\)
+            (.*)\
+        """), config, re.DOTALL)
+
+        # Should find all aliases
+        assert re.search('ServerAlias www\.archive\.asuc\.org modern\.asuc\.org www\.modern\.asuc\.org', m.group(1))
+
+        # Should find a VirtualHost for each port
+        assert re.search('\*:443.*\*:80', m.group(1), re.DOTALL)
+
+        # Should find correct docroot
+        assert re.search('DocumentRoot /services/http/users/s/staff', m.group(3))
+
+        # Shouldn't find SSL when [nossl] is present
+        assert not re.search('SSL', m.group(3))
+
+    @mock.patch(
+        'ocflib.vhost.application.get_app_vhost_db',
+        return_value=VHOSTS_APP_EXAMPLE.splitlines(),
+    )
+    def test_build_app_config(self, _):
+        config = build_app_config()
+
+        # Actually testing config files is hard, so just match some regexes
+        m = re.match(dedent("""\
+            # api\.asuc\.ocf\.berkeley\.edu \(user asucapp\)
+            (.*)
+            # dev-app\.ocf\.berkeley\.edu \(user ggroup\)
+            (.*)
+            # upe\.berkeley\.edu \(user upe\)
+            (.*)\
+        """), config, re.DOTALL)
+
+        # Should find all aliases
+        assert re.search(
+            'server_name "api\.asuc\.ocf\.berkeley\.edu"'
+            ' "api-asuc-ocf-berkeley-edu\.apphost\.ocf\.berkeley\.edu"'
+            ' "api\.asuc\.org";',
+            m.group(1)
+        )
+
+        # Should find a vhost for each port
+        assert re.search('listen 443;.*listen \[::\]:443;.*listen 80;.*listen \[::\]:80;', m.group(1), re.DOTALL)
+
+        # Should find correct socket
+        assert re.search('proxy_pass http://unix:/srv/apps/asucapp/prod\.sock', m.group(1))
+        assert re.search('proxy_pass http://unix:/srv/apps/upe/upe\.sock', m.group(3))

--- a/tests/vhost/web_test.py
+++ b/tests/vhost/web_test.py
@@ -12,7 +12,7 @@ VHOSTS_EXAMPLE = """
 asucarch archive.asuc.org www.archive.asuc.org,modern.asuc.org,www.modern.asuc.org -
 
 # [added 2015.04.16 ckuehl]
-staff! contrib - /contrib [nossl]
+staff contrib - /contrib [nossl]
 ocfwiki docs.ocf.berkeley.edu - - [hsts]
 """  # noqa
 
@@ -32,7 +32,7 @@ VHOSTS_EXAMPLE_PARSED = {
         'aliases': [],
         'docroot': '/contrib',
         'flags': ['nossl'],
-        'redirect': '/ https://www.ocf.berkeley.edu/~staff/',
+        'redirect': None,
         'username': 'staff',
     },
     'docs.ocf.berkeley.edu': {


### PR DESCRIPTION
As part of this addition, the app vhost config file now uses the same format as the regular vhost config file.

The corresponding changes to puppet will have to wait until revisions here are done.