### PR TITLE
Converge vhost config formats

### DIFF
--- a/ocflib/vhost/application.py
+++ b/ocflib/vhost/application.py
@@ -1,3 +1,5 @@
+import re
+
 import requests
 
 VHOST_DB_PATH = '/home/s/st/staff/vhost/vhost-app.conf'
@@ -19,15 +21,16 @@ def get_app_vhosts():
     """Returns a list of application virtual hosts in convenient format.
 
     >>> get_app_vhosts()
-    ...
     {
+    ...
         'ml.berkeley.edu': {
             'username': 'mlab',
-            'socket_name': 'mlab'
-            'ssl_cert': 'ml.berkeley.edu',
+            'socket': 'mlab'
+            'aliases': [],
+            'flags': []
         }
-    }
     ...
+    }
     """
     def fully_qualify(host):
         """Fully qualifies a hostname (by appending .berkeley.edu) if it's not
@@ -42,12 +45,18 @@ def get_app_vhosts():
 
         fields = line.split(' ')
 
-        username, host, socket, ssl_cert = fields
+        if len(fields) < 5:
+            flags = []
+        else:
+            flags = re.match('\[(.*)\]$', fields[4]).group(1).split(',')
+
+        username, host, socket, aliases = fields[:4]
 
         vhosts[fully_qualify(username if host == '-' else host)] = {
             'username': username,
             'socket': socket if socket != '-' else username,
-            'ssl_cert': ssl_cert if ssl_cert != '-' else None,
+            'aliases': aliases.split(',') if aliases != '-' else [],
+            'flags': flags,
         }
 
     return vhosts

--- a/ocflib/vhost/web.py
+++ b/ocflib/vhost/web.py
@@ -30,7 +30,7 @@ def get_vhosts():
             'username': 'bpr',
             'aliases': ['bpr.berkeley.edu'],
             'docroot': '/',
-            'redirect': None  # format is '/ https://some.other.site/'
+            'flags': [],
         }
     }
     ...
@@ -51,15 +51,9 @@ def get_vhosts():
         if len(fields) < 5:
             flags = []
         else:
-            flags = re.search('^\[(.*)\]$', fields[4]).group(1).split(',')
+            flags = re.match('\[(.*)\]$', fields[4]).group(1).split(',')
 
         username, host, aliases, docroot = fields[:4]
-
-        redirect = None
-
-        if username.endswith('!'):
-            username = username[:-1]
-            redirect = '/ https://www.ocf.berkeley.edu/~{}/'.format(username)
 
         if aliases != '-':
             aliases = list(map(fully_qualify, aliases.split(',')))
@@ -70,8 +64,7 @@ def get_vhosts():
             'username': username,
             'aliases': aliases,
             'docroot': '/' if docroot == '-' else docroot,
-            'redirect': redirect,
-            'flags': flags
+            'flags': flags,
         }
 
     return vhosts

--- a/tests/vhost/application_test.py
+++ b/tests/vhost/application_test.py
@@ -4,7 +4,7 @@ from ocflib.vhost.application import get_app_vhosts
 
 
 VHOSTS_EXAMPLE = """
-asucapp api.asuc.ocf.berkeley.edu prod api.asuc.ocf.berkeley.edu
+asucapp api.asuc.ocf.berkeley.edu prod api.asuc.org
 ggroup dev-app.ocf.berkeley.edu - -
 upe - - -
 """
@@ -12,18 +12,21 @@ upe - - -
 VHOSTS_EXAMPLE_PARSED = {
     'api.asuc.ocf.berkeley.edu': {
         'socket': 'prod',
-        'ssl_cert': 'api.asuc.ocf.berkeley.edu',
+        'aliases': ['api.asuc.org'],
         'username': 'asucapp',
+        'flags': [],
     },
     'dev-app.ocf.berkeley.edu': {
         'socket': 'ggroup',
-        'ssl_cert': None,
+        'aliases': [],
         'username': 'ggroup',
+        'flags': [],
     },
     'upe.berkeley.edu': {
         'socket': 'upe',
-        'ssl_cert': None,
+        'aliases': [],
         'username': 'upe',
+        'flags': [],
     },
 }
 
@@ -31,7 +34,7 @@ VHOSTS_EXAMPLE_PARSED = {
 class TestVirtualHosts:
 
     # The database-reading function is identical to that in vhost.web, so
-    # there's not much meaning in making tests slower by testing them.
+    # there's not much meaning in making tests slower by testing it.
 
     @mock.patch(
         'ocflib.vhost.application.get_app_vhost_db',

--- a/tests/vhost/web_test.py
+++ b/tests/vhost/web_test.py
@@ -12,7 +12,7 @@ VHOSTS_EXAMPLE = """
 asucarch archive.asuc.org www.archive.asuc.org,modern.asuc.org,www.modern.asuc.org -
 
 # [added 2015.04.16 ckuehl]
-staff! contrib - /contrib [nossl]
+staff contrib - /contrib [nossl]
 ocfwiki docs.ocf.berkeley.edu - - [hsts]
 """  # noqa
 
@@ -25,21 +25,18 @@ VHOSTS_EXAMPLE_PARSED = {
         ],
         'docroot': '/',
         'flags': [],
-        'redirect': None,
         'username': 'asucarch',
     },
     'contrib.berkeley.edu': {
         'aliases': [],
         'docroot': '/contrib',
         'flags': ['nossl'],
-        'redirect': '/ https://www.ocf.berkeley.edu/~staff/',
         'username': 'staff',
     },
     'docs.ocf.berkeley.edu': {
         'aliases': [],
         'docroot': '/',
         'flags': ['hsts'],
-        'redirect': None,
         'username': 'ocfwiki',
     },
 }


### PR DESCRIPTION
Since web applications should be getting SSL certs from Let's Encrypt,
this changes the last field in the app vhost config to contain a list of
alias domains where it previously had the name of the website's SSL
cert. This also removes the now-unused "!" syntax from the vhost file.