### PR TITLE
Replace pycrypto with pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,9 @@ setup(
         'ldap3',
         'paramiko',
         'pexpect',
-        'pycrypto',
+        'pycryptodome',
         'pymysql',
-        # 4.3.3 adds a dependency on "pycryptodome" which conflicts with pycrypto
-        'pysnmp<=4.3.2',
+        'pysnmp',
         'pyyaml',
         'redis',
         'requests',


### PR DESCRIPTION
`pycryptodome` appears to be a [drop in replacement for `pycrypto`](https://www.pycryptodome.org/en/latest/src/installation.html#installation), so this should work fine, I'll see if tests pass or not. ([rt#5885](https://rt.ocf.berkeley.edu/Ticket/Display.html?id=5885))