### PR TITLE
lab.stats: Tell if desktop is public by DNS record

### DIFF
--- a/ocflib/lab/stats.py
+++ b/ocflib/lab/stats.py
@@ -142,7 +142,7 @@ def list_desktops(public_only=False):
     if not public_only:
         filter = '(type=desktop)'
     else:
-        filter = '(&(type=desktop)(!(|(puppetVar=staff_only=true)(puppetVar=pubstaff_only=true))))'
+        filter = '(&(type=desktop)(!(|(dnsCname=frontdesk)(dnsCname=staffdesk))))'
 
     with ldap_ocf() as c:
         c.search(OCF_LDAP_HOSTS, filter, attributes=['cn'])

--- a/ocflib/lab/stats.py
+++ b/ocflib/lab/stats.py
@@ -142,7 +142,7 @@ def list_desktops(public_only=False):
     if not public_only:
         filter = '(type=desktop)'
     else:
-        filter = '(&(type=desktop)(!(|(dnsCname=frontdesk)(dnsCname=staffdesk))))'
+        filter = '(&(type=desktop)(!(|(dnsCname=frontdesk)(dnsA=staffdesk))))'
 
     with ldap_ocf() as c:
         c.search(OCF_LDAP_HOSTS, filter, attributes=['cn'])

--- a/tests/lab/stats_test.py
+++ b/tests/lab/stats_test.py
@@ -2,8 +2,6 @@ from datetime import date
 from datetime import datetime
 from datetime import timedelta
 
-import pytest
-
 from ocflib.lab.stats import list_desktops
 from ocflib.lab.stats import semester_dates
 from ocflib.lab.stats import UtilizationProfile
@@ -19,7 +17,6 @@ def test_list_desktops():
     assert 'death' not in desktops
 
 
-@pytest.mark.xfail(reason='staff_only moved to hiera broke test')
 def test_list_desktops_staff_only():
     desktops = list_desktops(public_only=True)
     assert 10 < len(desktops) < 50


### PR DESCRIPTION
Fixes https://github.com/ocf/ocflib/issues/85. This is probably better than using PuppetDB anyways, as that would introduce more network dependencies to ocflib and we might want to have a non-public test computer that still allows non-staff logins.