### PR TITLE
Don't leave a +3 file around in `make autoversion`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ clean: autoversion
 autoversion:
 	date +%Y.%-m.%-d.%-H.%-M > .version
 	rm -f debian/changelog
-	DEBFULLNAME="Open Computing Facility" DEBEMAIL="help@ocf.berkeley.edu" VISUAL=true \
+	DEBFULLNAME="Open Computing Facility" DEBEMAIL="help@ocf.berkeley.edu" \
 		dch -v `cat .version` -D stable --no-force-save-on-release \
 		--create --force-distribution --package "python-ocflib" "Package for Debian."
-	VISUAL=touch dch --local "~deb$(shell lsb_release -rs | cut -d . -f 1)u"
+	dch --local "~deb$(shell lsb_release -rs | cut -d . -f 1)u" \
+                "Package for $(shell lsb_release -cs)."


### PR DESCRIPTION
This unwanted file was getting created because `dch` invokes the
given editor roughly like:

    $VISUAL +linenum debian/changelog

Real editors interpret `+linenum` as a command to jump to the given
line number, but `touch` interprets it as another file to create.
We unfortunately have to continue using `touch` because the timestamp on
`debian/changelog` must be updated in order for `dch` to proceed.

We work around this problem by introducing a wrapper script which
feeds the proper argument to `touch`.