### PR TITLE
Changes to Staff hours yaml file and staff_hours.py

### DIFF
--- a/ocflib/lab/hours.py
+++ b/ocflib/lab/hours.py
@@ -189,6 +189,7 @@ class Day(namedtuple('Day', ['date', 'weekday', 'holiday', 'hours'])):
 HOLIDAYS = [
     # start date, end date, holiday name, list of hours (date ranges are inclusive)
     (date(2017, 5, 13), date(2017, 8, 23), 'Summer Break', []),
+    (date(2018, 1, 30), date(2018, 1, 30), 'Testing',[])
     (date(2017, 9, 3), date(2017, 9, 3), 'Early Lab Closure', [Hour(time(11), time(18))]),
     (date(2017, 9, 4), date(2017, 9, 4), 'Labor Day', []),
     (date(2017, 9, 5), date(2017, 9, 5), 'Early Lab Closure', [Hour(time(9), time(19))]),

--- a/ocflib/lab/hours.py
+++ b/ocflib/lab/hours.py
@@ -189,7 +189,6 @@ class Day(namedtuple('Day', ['date', 'weekday', 'holiday', 'hours'])):
 HOLIDAYS = [
     # start date, end date, holiday name, list of hours (date ranges are inclusive)
     (date(2017, 5, 13), date(2017, 8, 23), 'Summer Break', []),
-    (date(2018, 1, 30), date(2018, 1, 30), 'Testing',[])
     (date(2017, 9, 3), date(2017, 9, 3), 'Early Lab Closure', [Hour(time(11), time(18))]),
     (date(2017, 9, 4), date(2017, 9, 4), 'Labor Day', []),
     (date(2017, 9, 5), date(2017, 9, 5), 'Early Lab Closure', [Hour(time(9), time(19))]),

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -135,12 +135,15 @@ def get_staff_hours_soonest_first():
         def parse_time_string_with_am_pm(time):
             num_of_secs = 0
             am_or_pm = None 
-            time_string_start = time[:time.index('-')]
-            am_or_pm = time_string_start[-2]
+            time_string_end = time[time.index('-') + 1:]
+            print("time string end is;" + time_string_end)
+            time_string_end = time_string_end.strip()
+            print("time string end after strip:" + time_string_end)
+            am_or_pm = time_string_end[-2]
             if (am_or_pm == 'p'):
                 print(am_or_pm)
                 num_of_secs = seconds_in_half_a_day
-            num_of_secs +=  convert_to_sec_from_day_start(time_string_start[:-2])
+            num_of_secs +=  convert_to_sec_from_day_start(time_string_end[:-2])
             return num_of_secs
         
         def parse_time_string_no_am_pm(time):

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -12,11 +12,11 @@ from ocflib.account.utils import is_staff
 from ocflib.misc.mail import email_for_user
 
 
-STAFF_HOURS_FILE = '/home/s/st/staff/staff_hours.yaml'
+STAFF_HOURS_FILE = '/home/s/st/staff/staff_hours_example_vaibhav.yaml'
 STAFF_HOURS_URL = 'https://www.ocf.berkeley.edu/~staff/staff_hours.yaml'
 
-
-Hour = namedtuple('Hour', ['day', 'time', 'staff', 'cancelled'])
+Staffday = namedtuple('Staffday', ['day','hours']) 
+Hour = namedtuple('Hour', ['time', 'staff', 'cancelled'])
 
 
 class Staffer(namedtuple('Staffer', ['user_name', 'real_name', 'position'])):
@@ -38,10 +38,12 @@ def _load_staff_hours():
         # fall back to loading from web
         return yaml.safe_load(requests.get(STAFF_HOURS_URL).text)
 
-
 def get_staff_hours():
-    staff_hours = _load_staff_hours()
+    staff_hours = load_staff_hours()
+    print(staff_hours)
+    return  [Staffday(day = staff_day,get_staff_hours_per_day(staff_hours[staff_day])) for staff_hour in staff_hours]
 
+def get_staff_hours_per_day(day):
     def position(uid):
         if uid in staff_hours['staff-positions']:
             return staff_hours['staff-positions'][uid]
@@ -49,11 +51,8 @@ def get_staff_hours():
             return 'Technical Manager'
         else:
             return 'Staff Member'
-
     return [
-        Hour(
-            day=hour['day'],
-            time=hour['time'],
+        Hour(time = hour,
             staff=[
                 Staffer(
                     user_name=attrs['uid'][0],
@@ -62,8 +61,8 @@ def get_staff_hours():
                 ) for attrs in map(user_attrs, hour['staff'])
             ],
             cancelled=hour['cancelled'],
-        ) for hour in staff_hours['staff-hours']
-    ]
+        ) for hour in day ]
+
 
 
 def _remove_middle_names(name):

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -42,13 +42,22 @@ def _load_staff_hours():
 def get_staff_hours():
     lst_of_staff_days= []
     staff_hours = _load_staff_hours()
-
+    string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 
+            'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
     def check_hours_cancelled(lst_of_hours):
         for hour in lst_of_hours:
             if (getattr(hour,'cancelled') == False):
                 return False
         return True
 
+    def date_is_holiday(name_of_day):
+        #come up with a better way to convert from the day given in the textfile
+        today = date.today() 
+        modded_day = today.isoweekday() % string_to_constant['Sunday'] 
+        date_object = Day.from_date(today + timedelta(days = 
+                        string_to_constant[name_of_day] - modded_day))
+        return date_object.holiday
+    
     hour_info = staff_hours['staff-hours']
     for staff_day in hour_info:
         hours_for_day = get_staff_hours_per_day(hour_info[staff_day],staff_hours, staff_day)
@@ -57,8 +66,8 @@ def get_staff_hours():
         lst_of_staff_days.append(Staffday(day = staff_day, hours = hours_for_day, 
                 no_staff_hours_today = all_hours_cancelled,
                 holiday = my_holiday))
-    print (lst_of_staff_days)
-    return lst_of_staff_days
+    return sorted(lst_of_staff_days, key = lambda staff_day: 
+                string_to_constant[staff_day.day])
 
 def get_staff_hours_per_day(day, staff_hours, name_of_day):
     def position(uid):
@@ -94,10 +103,3 @@ def get_staff_hours_soonest_first():
     hours = list(chain.from_iterable([day.hours for day in sorted_days]))
     return(hours)
 
-def date_is_holiday(name_of_day):
-    #come up with a better way to convert from the day given in the textfile
-    string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
-    today = date.today() 
-    modded_day = today.isoweekday() % string_to_constant['Sunday'] 
-    date_object = Day.from_date(today + timedelta(days = string_to_constant[name_of_day] - modded_day))
-    return date_object.holiday

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -76,5 +76,4 @@ def get_staff_hours_soonest_first():
     #change to include the next two staff hours not the first two in a day
     sorted_days = sorted(get_staff_hours(), key=lambda hour: days.index(hour.day))
     hours = list(chain.from_iterable([day.hours for day in sorted_days]))
-    print(hours)
     return(hours)

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -119,7 +119,7 @@ def get_staff_hours_soonest_first():
             if (colon_index != -1):
                 print(type(digital_time_string))
                 secs += float((digital_time_string[colon_index + 1:]).strip())* seconds_in_a_min
-            secs += float((digital_time_string[:colon_index]).strip()) * seconds_in_an_hour
+            secs += int((digital_time_string[:colon_index]).strip()) * seconds_in_an_hour
             return secs
 
         def parse_time_string_with_am_pm(time):
@@ -145,7 +145,7 @@ def get_staff_hours_soonest_first():
         day = hour.day
         day_diff = today.isoweekday() - string_to_constant[day]
         staff_hours_seconds = parse_time_string_with_am_pm(time_as_string)
-        now = date.date.now().strftime("%H:%M")
+        now = date.datetime.now().strftime("%H:%M")
         seconds_now = parse_time_string_no_am_pm(now)
         earlier_in_day_or_earlier_in_week = day_diff < 0 \
                 or today.isoweekday() == string_to_constant[day] \

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -71,7 +71,6 @@ def get_staff_hours():
                 holiday = my_holiday))
     sorted_days = sorted(lst_of_staff_days, key = lambda staff_day: 
                 string_to_constant[staff_day.day])
-    print("In OCFLIB")
     return sorted_days
 
 def get_staff_hours_per_day(day, staff_hours, name_of_day):
@@ -112,23 +111,20 @@ def get_staff_hours_soonest_first():
         days_in_week = 7
         string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 
             'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
-   
+        time_as_string = hour.time
+        day = hour.day
+        day_diff = today.isoweekday() - string_to_constant[day]
+        now = dtime.now().strftime("%H:%M")
+        
         def convert_to_sec_from_day_start(digital_time_string):
-            print("digital_time:" + digital_time_string)
             secs = 0
             colon_index = digital_time_string.find(":")
             if (colon_index != -1):
-                print(type(digital_time_string))
                 secs += int((digital_time_string[colon_index + 1:]).strip()) \
                         * seconds_in_a_min
                 secs += int((digital_time_string[:colon_index]).strip()) \
                         * seconds_in_a_hour
             else:
-                print("hello")
-                print("bye")
-                print("len is" + str(len(digital_time_string)))
-                print("type is" + str(type(digital_time_string)))
-                print(digital_time_string)
                 secs += int((digital_time_string).strip()) * seconds_in_a_hour
             return secs
 
@@ -136,43 +132,27 @@ def get_staff_hours_soonest_first():
             num_of_secs = 0
             am_or_pm = None 
             time_string_end = time[time.index('-') + 1:]
-            print("time string end is;" + time_string_end)
             time_string_end = time_string_end.strip()
-            print("time string end after strip:" + time_string_end)
             am_or_pm = time_string_end[-2]
             if (am_or_pm == 'p'):
-                print(am_or_pm)
                 num_of_secs = seconds_in_half_a_day
             num_of_secs +=  convert_to_sec_from_day_start(time_string_end[:-2])
             return num_of_secs
         
         def parse_time_string_no_am_pm(time):
-            secs = 0
-            print("parse time string no am_pm: " + time)
-            colon_index = time.find(":")
-            secs += int(time[colon_index + 1:]) * seconds_in_a_min
-            print("Secs now time 2:" + str(secs))
-            secs += int(time[:colon_index]) * seconds_in_a_hour
-            print("secs now time 3:" + str(secs))
-            return secs
+            return convert_to_sec_from_day_start(time)
         
-        time_as_string = hour.time
-        day = hour.day
-        day_diff = today.isoweekday() - string_to_constant[day]
         staff_hours_seconds = parse_time_string_with_am_pm(time_as_string)
-        print("return of parse_time_String:" + str(parse_time_string_with_am_pm(time_as_string)))
-        print("staff_hour second:" + str(staff_hours_seconds))
-        now = dtime.now().strftime("%H:%M")
         today_time_in_sec =  parse_time_string_no_am_pm(now)
         earlier_in_day_or_earlier_in_week = day_diff < 0 \
                 or today.isoweekday() == string_to_constant[day] \
                 and staff_hours_seconds < today_time_in_sec
+        
         if (earlier_in_day_or_earlier_in_week):
             day_diff += days_in_week
 
         hours_away_in_sec += day_diff * seconds_in_day 
         hours_away_in_sec += staff_hours_seconds - today_time_in_sec 
-        print("hours_Away" + str(day) + ":" + str(time_as_string) + "-" + str(hours_away_in_sec))
         return hours_away_in_sec
         
 

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -114,8 +114,6 @@ def get_staff_hours_soonest_first():
         time_as_string = hour.time
         day = hour.day
         day_diff = string_to_constant[day] - today.isoweekday()
-        print("day:" + str(day))
-        print("day_diff" + str(day_diff))
         now = dtime.now().strftime("%H:%M")
         
         def convert_to_sec_from_day_start(digital_time_string):
@@ -150,8 +148,6 @@ def get_staff_hours_soonest_first():
                 or today.isoweekday() == string_to_constant[day] \
                 and staff_hours_seconds < today_time_in_sec 
         if (earlier_in_day_or_earlier_in_week):
-            print("day:" + str(day))
-            print("daydiff:" + str(day))
             day_diff += days_in_week
 
         hours_away_in_sec += day_diff * seconds_in_day 

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -101,16 +101,53 @@ def _remove_middle_names(name):
 
 def get_staff_hours_soonest_first():
     def determine_hours_away(hour):
-        def parse_time_string(time):
+        now = 0
+        hours_away_in_sec = 0
+        seconds_in_half_a_day = 12 * 3600
+        seconds_in_an_hour = 3600
+        seconds_in_a_min = 60
+        days_in_week = 7
+        string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 
+            'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
+   
+        def convert_to_sec_from_day_start(digital_time_string):
+            secs = 0
+            colon_index = digital_time_string.find(":")
+            if (colon_index != -1):
+                secs += digital_time_string[colon_index + 1:] * seconds_in_a_min
+            secs += digital_time_string[:colon_index] * seconds_in_an_hour
+            return secs
+
+        def parse_time_string_with_am_pm(time):
+            num_of_secs = 0
+            am_or_pm = None 
             time_string_start = time[:time.index('-')]
             am_or_pm = time_string_start[-2]
-            if (am_or_pm == 'a'):
+            if (am_or_pm == 'p'):
+                num_of_secs = seconds_in_half_a_day
+            num_of_secs +=  convert_to_sec_from_day_start(time_string_start[:-2])
+            return num_of_secs
+        
+        def parse_time_string_no_am_pm(time):
+            secs = 0
+            colon_index = time.find(":")
+            if (colon_index != -1):
+                secs += time[colon_index + 1:] * seconds_in_a_min
+            secs += convert_to_sec_from_day_start(time[:colon_index]) * seconds_in_a_hour
+            return secs
 
-            
-            
-            
         time_as_string = hour[time]
         day = hour[day]
+        day_diff = today.isoweekday() - string_to_constant[day]
+        staff_hours_seconds = parse_time_string(time_as_string)
+        now = datetime.datetime.now().strftime("%H:%M")
+        seconds_now = parse_time_string_no_am_pm(now)
+        if (day_diff < 0 or staff_hours_seconds < today_second):
+            day_diff += days_in_week
+        hours_away_in_sec += day_diff
+        hours_away_in_sec += staff_hours_seconds + (hours_in_a_day
+        return hours_away_in_sec
+        
 
     today = date.today()
     days = [(today + timedelta(days=i)).strftime('%A') for i in range(7)]

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -16,8 +16,8 @@ STAFF_HOURS_FILE = '/home/s/st/staff/staff_hours_example_vaibhav.yaml'
 STAFF_HOURS_URL = 'https://www.ocf.berkeley.edu/~staff/staff_hours.yaml'
 
 Staffday = namedtuple('Staffday', ['day','hours']) 
-Hour = namedtuple('Hour', ['time', 'staff', 'cancelled'])
-
+Staffhour = namedtuple('Staffhour', ['time', 'staff', 'cancelled'])
+Hour = namedtuple('Hour', ['day', 'time', 'staff', 'cancelled'])
 
 class Staffer(namedtuple('Staffer', ['user_name', 'real_name', 'position'])):
 
@@ -41,7 +41,7 @@ def _load_staff_hours():
 def get_staff_hours():
     staff_hours = _load_staff_hours()
     hour_info = staff_hours['staff-hours']
-    print([Staffday(day = staff_day, hours = get_staff_hours_per_day(hour_info[staff_day], staff_hours)) for staff_day in hour_info])
+    return [Staffday(day = staff_day, hours = get_staff_hours_per_day(hour_info[staff_day], staff_hours)) for staff_day in hour_info]
 
 def get_staff_hours_per_day(day, staff_hours):
     def position(uid):
@@ -51,9 +51,8 @@ def get_staff_hours_per_day(day, staff_hours):
             return 'Technical Manager'
         else:
             return 'Staff Member'
-    print([day[hour] for hour in day])
     return [
-        Hour(time = hour,
+        Staffhour(time = hour,
             staff=[
                 Staffer(
                     user_name=attrs['uid'][0],

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -113,7 +113,9 @@ def get_staff_hours_soonest_first():
             'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
         time_as_string = hour.time
         day = hour.day
-        day_diff = today.isoweekday() - string_to_constant[day]
+        day_diff = string_to_constant[day] - today.isoweekday()
+        print("day:" + str(day))
+        print("day_diff" + str(day_diff))
         now = dtime.now().strftime("%H:%M")
         
         def convert_to_sec_from_day_start(digital_time_string):
@@ -146,9 +148,10 @@ def get_staff_hours_soonest_first():
         today_time_in_sec =  parse_time_string_no_am_pm(now)
         earlier_in_day_or_earlier_in_week = day_diff < 0 \
                 or today.isoweekday() == string_to_constant[day] \
-                and staff_hours_seconds < today_time_in_sec
-        
+                and staff_hours_seconds < today_time_in_sec 
         if (earlier_in_day_or_earlier_in_week):
+            print("day:" + str(day))
+            print("daydiff:" + str(day))
             day_diff += days_in_week
 
         hours_away_in_sec += day_diff * seconds_in_day 

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -102,6 +102,12 @@ def _remove_middle_names(name):
 def get_staff_hours_soonest_first():
     def determine_hours_away(hour):
         def parse_time_string(time):
+            time_string_start = time[:time.index('-')]
+            am_or_pm = time_string_start[-2]
+            if (am_or_pm == 'a'):
+
+            
+            
             
         time_as_string = hour[time]
         day = hour[day]

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -76,6 +76,14 @@ def parse_time_string_with_am_pm(time, end = True):
     num_of_secs +=  convert_to_sec_from_day_start(time_string_end[:-2])
     return num_of_secs
 
+def date_is_holiday(name_of_day):
+    #come up with a better way to convert from the day given in the textfile
+    today = date.today() 
+    modded_day = today.isoweekday() % string_to_constant['Sunday'] 
+    date_object = Day.from_date(today + timedelta(days = 
+                                    string_to_constant[name_of_day] - modded_day))
+    return date_object.holiday
+
 def get_staff_hours():
     lst_of_staff_days= []
     staff_hours = _load_staff_hours()
@@ -85,17 +93,8 @@ def get_staff_hours():
             if (getattr(hour,'cancelled') == False):
                 return False
         return True
-
-    def date_is_holiday(name_of_day):
-        #come up with a better way to convert from the day given in the textfile
-        today = date.today() 
-        modded_day = today.isoweekday() % string_to_constant['Sunday'] 
-        date_object = Day.from_date(today + timedelta(days = 
-                        string_to_constant[name_of_day] - modded_day))
-        return date_object.holiday
     
     hour_info = staff_hours['staff-hours']
-    print(hour_info)
     for staff_day in hour_info:
         hours_for_day = get_staff_hours_per_day(hour_info[staff_day],
                         staff_hours, staff_day)
@@ -171,7 +170,8 @@ def get_staff_hours_soonest_first():
 
     hours = chain.from_iterable([staff_day.hours for staff_day in get_staff_hours()])
     hours = sorted(hours, key = lambda x: determine_hours_away(x))
-    hours_with_no_cancelled_hours  = [hour for hour in hours if not hour.cancelled]
+    hours = [hour for hour in hours if not hour.cancelled]
+    hours_with_no_cancelled_hours = [hour for hour in hours if not date_is_holiday(hour.day)] 
     return(hours_with_no_cancelled_hours)
 
 

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -18,30 +18,17 @@ from ocflib.misc.mail import email_for_user
 
 STAFF_HOURS_FILE = '/home/s/st/staff/staff_hours_example_vaibhav.yaml'
 STAFF_HOURS_URL = 'https://www.ocf.berkeley.edu/~staff/staff_hours.yaml'
-STAFF_BIOS_FILE = '/home/s/st/staff/staff_bios_example_vaibhav.yaml'
-STAFF_BIOS_URL = 'https://www.ocf.berkeley.edu/~staff/vaibhav.yaml'
 Staffday = namedtuple('Staffday', ['day','hours','no_staff_hours_today', 'holiday']) 
 Hour = namedtuple('Hour', ['day', 'time', 'staff', 'cancelled'])
 
 string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 
         'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
 
-default_staff_bio_string = "I spend every waking minute of my life at the OCF."
-hours_away_in_sec = 0
 seconds_in_day = 24 * 3600
 seconds_in_half_a_day = 12 * 3600
 seconds_in_a_hour = 3600
 seconds_in_a_min = 60
-
-def _load_staff_bios():
-    """Load staff bios"""
-    try:
-        with open(STAFF_BIOS_FILE) as f:
-            return yaml.safe_load(f)
-    except IOError:
-        return yaml.safe_load(requests.get(STAFF_BIOS_URL).text)
-staff_bios = _load_staff_bios()
-print(staff_bios)
+days_in_week = 7
 
 class Staffer(namedtuple('Staffer', ['user_name', 'real_name', 'position'])):
     def gravatar(self, size=100):
@@ -50,12 +37,6 @@ class Staffer(namedtuple('Staffer', ['user_name', 'real_name', 'position'])):
             hash=md5(email.lower().encode('utf-8')).hexdigest(),
             params=urlencode({'d': 'mm', 's': size}),
         )
-
-    def get_bio(self):
-        staff_bio = staff_bios.get(self.user_name, default_staff_bio_string)
-        return staff_bio
-        
-
 
 def _load_staff_hours():
     """Load staff hours, either from disk (if available) or HTTP."""
@@ -159,11 +140,6 @@ def get_staff_hours_soonest_first():
     def determine_hours_away(hour):
         now = 0
         hours_away_in_sec = 0
-        seconds_in_day = 24 * 3600
-        seconds_in_half_a_day = 12 * 3600
-        seconds_in_a_hour = 3600
-        seconds_in_a_min = 60
-        days_in_week = 7
         time_as_string = hour.time
         day = hour.day
         day_diff = string_to_constant[day] - today.isoweekday()

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -18,14 +18,15 @@ from ocflib.misc.mail import email_for_user
 
 STAFF_HOURS_FILE = '/home/s/st/staff/staff_hours_example_vaibhav.yaml'
 STAFF_HOURS_URL = 'https://www.ocf.berkeley.edu/~staff/staff_hours.yaml'
-STAFF_BIOS_FILE = 'home/s/st/staff/staff_bios_example_vaibhav.yaml'
-STAFF_BIOS_URL = ''
+STAFF_BIOS_FILE = '/home/s/st/staff/staff_bios_example_vaibhav.yaml'
+STAFF_BIOS_URL = 'https://www.ocf.berkeley.edu/~staff/vaibhav.yaml'
 Staffday = namedtuple('Staffday', ['day','hours','no_staff_hours_today', 'holiday']) 
 Hour = namedtuple('Hour', ['day', 'time', 'staff', 'cancelled'])
 
 string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 
         'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
 
+default_staff_bio_string = "I spend every waking minute of my life at the OCF."
 hours_away_in_sec = 0
 seconds_in_day = 24 * 3600
 seconds_in_half_a_day = 12 * 3600
@@ -38,8 +39,9 @@ def _load_staff_bios():
         with open(STAFF_BIOS_FILE) as f:
             return yaml.safe_load(f)
     except IOError:
-        return yaml.safe_load(requests.get(STAFF_BIOS_URL).txt)
+        return yaml.safe_load(requests.get(STAFF_BIOS_URL).text)
 staff_bios = _load_staff_bios()
+print(staff_bios)
 
 class Staffer(namedtuple('Staffer', ['user_name', 'real_name', 'position'])):
     def gravatar(self, size=100):
@@ -50,7 +52,7 @@ class Staffer(namedtuple('Staffer', ['user_name', 'real_name', 'position'])):
         )
 
     def get_bio(self):
-        staff_bio = staff_bios[self.username]
+        staff_bio = staff_bios.get(self.user_name, default_staff_bio_string)
         return staff_bio
         
 

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -60,14 +60,18 @@ def get_staff_hours():
     
     hour_info = staff_hours['staff-hours']
     for staff_day in hour_info:
-        hours_for_day = get_staff_hours_per_day(hour_info[staff_day],staff_hours, staff_day)
+        hours_for_day = get_staff_hours_per_day(hour_info[staff_day],
+                        staff_hours, staff_day)
         all_hours_cancelled = check_hours_cancelled(hours_for_day)
         my_holiday = date_is_holiday(staff_day)
-        lst_of_staff_days.append(Staffday(day = staff_day, hours = hours_for_day, 
+        lst_of_staff_days.append(Staffday(day = staff_day, 
+                hours = hours_for_day, 
                 no_staff_hours_today = all_hours_cancelled,
                 holiday = my_holiday))
-    return sorted(lst_of_staff_days, key = lambda staff_day: 
+    sorted_days = sorted(lst_of_staff_days, key = lambda staff_day: 
                 string_to_constant[staff_day.day])
+    print("In OCFLIB")
+    return sorted_days
 
 def get_staff_hours_per_day(day, staff_hours, name_of_day):
     def position(uid):
@@ -96,6 +100,12 @@ def _remove_middle_names(name):
 
 
 def get_staff_hours_soonest_first():
+    def determine_hours_away(hour):
+        def parse_time_string(time):
+            
+        time_as_string = hour[time]
+        day = hour[day]
+
     today = date.today()
     days = [(today + timedelta(days=i)).strftime('%A') for i in range(7)]
     #change to include the next two staff hours not the first two in a day

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from datetime import date
+from datetime import datetime as dtime
 from datetime import timedelta
 from hashlib import md5
 from urllib.parse import urlencode
@@ -106,20 +107,29 @@ def get_staff_hours_soonest_first():
         hours_away_in_sec = 0
         seconds_in_day = 24 * 3600
         seconds_in_half_a_day = 12 * 3600
-        seconds_in_an_hour = 3600
+        seconds_in_a_hour = 3600
         seconds_in_a_min = 60
         days_in_week = 7
         string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 
             'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
    
         def convert_to_sec_from_day_start(digital_time_string):
-            print(digital_time_string)
+            print("digital_time:" + digital_time_string)
             secs = 0
             colon_index = digital_time_string.find(":")
             if (colon_index != -1):
                 print(type(digital_time_string))
-                secs += float((digital_time_string[colon_index + 1:]).strip())* seconds_in_a_min
-            secs += int((digital_time_string[:colon_index]).strip()) * seconds_in_an_hour
+                secs += int((digital_time_string[colon_index + 1:]).strip()) \
+                        * seconds_in_a_min
+                secs += int((digital_time_string[:colon_index]).strip()) \
+                        * seconds_in_a_hour
+            else:
+                print("hello")
+                print("bye")
+                print("len is" + str(len(digital_time_string)))
+                print("type is" + str(type(digital_time_string)))
+                print(digital_time_string)
+                secs += int((digital_time_string).strip()) * seconds_in_a_hour
             return secs
 
         def parse_time_string_with_am_pm(time):
@@ -135,32 +145,37 @@ def get_staff_hours_soonest_first():
         
         def parse_time_string_no_am_pm(time):
             secs = 0
+            print("parse time string no am_pm: " + time)
             colon_index = time.find(":")
-            if (colon_index != -1):
-                secs += int(time[colon_index + 1:]) * seconds_in_a_min
-            secs += convert_to_sec_from_day_start(time[:colon_index]) * seconds_in_a_hour
+            secs += int(time[colon_index + 1:]) * seconds_in_a_min
+            print("Secs now time 2:" + str(secs))
+            secs += int(time[:colon_index]) * seconds_in_a_hour
+            print("secs now time 3:" + str(secs))
             return secs
         
         time_as_string = hour.time
         day = hour.day
         day_diff = today.isoweekday() - string_to_constant[day]
         staff_hours_seconds = parse_time_string_with_am_pm(time_as_string)
-        now = date.datetime.now().strftime("%H:%M")
-        seconds_now = parse_time_string_no_am_pm(now)
+        print("return of parse_time_String:" + str(parse_time_string_with_am_pm(time_as_string)))
+        print("staff_hour second:" + str(staff_hours_seconds))
+        now = dtime.now().strftime("%H:%M")
+        today_time_in_sec =  parse_time_string_no_am_pm(now)
         earlier_in_day_or_earlier_in_week = day_diff < 0 \
                 or today.isoweekday() == string_to_constant[day] \
-                and staff_hours_second < today_second
+                and staff_hours_seconds < today_time_in_sec
         if (earlier_in_day_or_earlier_in_week):
             day_diff += days_in_week
 
         hours_away_in_sec += day_diff * seconds_in_day 
-        hours_away_in_sec += staff_hour_seconds - seconds_now
+        hours_away_in_sec += staff_hours_seconds - today_time_in_sec 
+        print("hours_Away" + str(day) + ":" + str(time_as_string) + "-" + str(hours_away_in_sec))
         return hours_away_in_sec
         
 
     hours = chain.from_iterable([staff_day.hours for staff_day in get_staff_hours()])
-    print(hours)
     hours = sorted(hours, key = lambda x: determine_hours_away(x))
-    return(hours)
+    hours_with_no_cancelled_hours  = [hour for hour in hours if not hour.cancelled]
+    return(hours_with_no_cancelled_hours)
 
 

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -39,11 +39,11 @@ def _load_staff_hours():
         return yaml.safe_load(requests.get(STAFF_HOURS_URL).text)
 
 def get_staff_hours():
-    staff_hours = load_staff_hours()
-    print(staff_hours)
-    return  [Staffday(day = staff_day,get_staff_hours_per_day(staff_hours[staff_day])) for staff_hour in staff_hours]
+    staff_hours = _load_staff_hours()
+    hour_info = staff_hours['staff-hours']
+    print([Staffday(day = staff_day, hours = get_staff_hours_per_day(hour_info[staff_day], staff_hours)) for staff_day in hour_info])
 
-def get_staff_hours_per_day(day):
+def get_staff_hours_per_day(day, staff_hours):
     def position(uid):
         if uid in staff_hours['staff-positions']:
             return staff_hours['staff-positions'][uid]
@@ -51,6 +51,7 @@ def get_staff_hours_per_day(day):
             return 'Technical Manager'
         else:
             return 'Staff Member'
+    print([day[hour] for hour in day])
     return [
         Hour(time = hour,
             staff=[
@@ -58,9 +59,9 @@ def get_staff_hours_per_day(day):
                     user_name=attrs['uid'][0],
                     real_name=_remove_middle_names(attrs['cn'][0]),
                     position=position(attrs['uid'][0]),
-                ) for attrs in map(user_attrs, hour['staff'])
+                ) for attrs in map(user_attrs, day[hour]['staff'])
             ],
-            cancelled=hour['cancelled'],
+            cancelled= day[hour]['cancelled'],
         ) for hour in day ]
 
 

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -3,32 +3,32 @@ from datetime import date
 from datetime import datetime as dtime
 from datetime import timedelta
 from hashlib import md5
-from urllib.parse import urlencode
 from itertools import chain
+from urllib.parse import urlencode
 
 import requests
 import yaml
-import json
 
-from ocflib.lab.hours import Day
 from ocflib.account.search import user_attrs
 from ocflib.account.utils import is_staff
+from ocflib.lab.hours import Day
 from ocflib.misc.mail import email_for_user
 
 
 STAFF_HOURS_FILE = '/home/s/st/staff/staff_hours_example_vaibhav.yaml'
 STAFF_HOURS_URL = 'https://www.ocf.berkeley.edu/~staff/staff_hours.yaml'
-Staffday = namedtuple('Staffday', ['day','hours','no_staff_hours_today', 'holiday']) 
+Staffday = namedtuple('Staffday', ['day', 'hours', 'no_staff_hours_today', 'holiday'])
 Hour = namedtuple('Hour', ['day', 'time', 'staff', 'cancelled'])
 
-string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 
-        'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
+string_to_constant = {'Monday': 1, 'Tuesday': 2, 'Wednesday': 3,
+                      'Thursday': 4, 'Friday': 5, 'Saturday': 6, 'Sunday': 7}
 
 seconds_in_day = 24 * 3600
 seconds_in_half_a_day = 12 * 3600
 seconds_in_a_hour = 3600
 seconds_in_a_min = 60
 days_in_week = 7
+
 
 class Staffer(namedtuple('Staffer', ['user_name', 'real_name', 'position'])):
     def gravatar(self, size=100):
@@ -37,6 +37,7 @@ class Staffer(namedtuple('Staffer', ['user_name', 'real_name', 'position'])):
             hash=md5(email.lower().encode('utf-8')).hexdigest(),
             params=urlencode({'d': 'mm', 's': size}),
         )
+
 
 def _load_staff_hours():
     """Load staff hours, either from disk (if available) or HTTP."""
@@ -47,9 +48,10 @@ def _load_staff_hours():
         # fall back to loading from web
         return yaml.safe_load(requests.get(STAFF_HOURS_URL).text)
 
+
 def convert_to_sec_from_day_start(digital_time_string):
     secs = 0
-    colon_index = digital_time_string.find(":")
+    colon_index = digital_time_string.find(':')
     if (colon_index != -1):
         secs += int((digital_time_string[colon_index + 1:]).strip()) \
             * seconds_in_a_min
@@ -59,9 +61,10 @@ def convert_to_sec_from_day_start(digital_time_string):
         secs += int((digital_time_string).strip()) * seconds_in_a_hour
     return secs
 
-def parse_time_string_with_am_pm(time, end = True):
+
+def parse_time_string_with_am_pm(time, end=True):
     num_of_secs = 0
-    am_or_pm = None 
+    am_or_pm = None
     time_string_end = None
     if (time_string_end):
         time_string_end = time[time.index('-') + 1:]
@@ -71,43 +74,45 @@ def parse_time_string_with_am_pm(time, end = True):
     am_or_pm = time_string_end[-2]
     if (am_or_pm == 'p'):
         num_of_secs = seconds_in_half_a_day
-    num_of_secs +=  convert_to_sec_from_day_start(time_string_end[:-2])
+    num_of_secs += convert_to_sec_from_day_start(time_string_end[:-2])
     return num_of_secs
 
+
 def date_is_holiday(name_of_day):
-    #come up with a better way to convert from the day given in the textfile
-    today = date.today() 
-    modded_day = today.isoweekday() % string_to_constant['Sunday'] 
-    date_object = Day.from_date(today + timedelta(days = 
-                                    string_to_constant[name_of_day] - modded_day))
+    # come up with a better way to convert from the day given in the textfile
+    today = date.today()
+    modded_day = today.isoweekday() % string_to_constant['Sunday']
+    date_object = Day.from_date(today + timedelta(days=string_to_constant[name_of_day] - modded_day))
     return date_object.holiday
 
+
 def get_staff_hours():
-    lst_of_staff_days= []
+    lst_of_staff_days = []
     staff_hours = _load_staff_hours()
 
     def check_hours_cancelled(lst_of_hours):
         for hour in lst_of_hours:
-            if (getattr(hour,'cancelled') == False):
+            if (getattr(hour, 'cancelled') is False):
                 return False
         return True
-    
+
     hour_info = staff_hours['staff-hours']
     for staff_day in hour_info:
         hours_for_day = get_staff_hours_per_day(hour_info[staff_day],
-                        staff_hours, staff_day)
+                                                staff_hours, staff_day)
         all_hours_cancelled = check_hours_cancelled(hours_for_day)
         my_holiday = date_is_holiday(staff_day)
-        lst_of_staff_days.append(Staffday(day = staff_day, 
-                hours = hours_for_day, 
-                no_staff_hours_today = all_hours_cancelled,
-                holiday = my_holiday))
-    sorted_days = sorted(lst_of_staff_days, key = lambda staff_day: 
-                string_to_constant[staff_day.day])
+        lst_of_staff_days.append(Staffday(day=staff_day,
+                                          hours=hours_for_day,
+                                          no_staff_hours_today=all_hours_cancelled,
+                                          holiday=my_holiday))
+    sorted_days = sorted(lst_of_staff_days, key=lambda staff_day:
+                         string_to_constant[staff_day.day])
     return sorted_days
 
+
 def get_staff_hours_per_day(day, staff_hours, name_of_day):
-    
+
     def position(uid):
         if uid in staff_hours['staff-positions']:
             return staff_hours['staff-positions'][uid]
@@ -117,53 +122,53 @@ def get_staff_hours_per_day(day, staff_hours, name_of_day):
             return 'Staff Member'
 
     return sorted([
-        Hour(day = name_of_day, time = hour,
-            staff=[
-                Staffer(
-                    user_name=attrs['uid'][0],
-                    real_name=_remove_middle_names(attrs['cn'][0]),
-                    position=position(attrs['uid'][0]),
-                ) for attrs in map(user_attrs, day[hour]['staff'])
-            ],
-            cancelled = day[hour]['cancelled'],
-            ) for hour in day ], key = lambda hour: 
-                parse_time_string_with_am_pm(hour.time, False))
-                    
+        Hour(day=name_of_day, time=hour,
+             staff=[
+                 Staffer(
+                     user_name=attrs['uid'][0],
+                     real_name=_remove_middle_names(attrs['cn'][0]),
+                     position=position(attrs['uid'][0]),
+                 ) for attrs in map(user_attrs, day[hour]['staff'])
+             ],
+             cancelled=day[hour]['cancelled'] or
+             date_is_holiday(name_of_day),
+             ) for hour in day], key=lambda hour:
+        parse_time_string_with_am_pm(hour.time, False))
+
 
 def _remove_middle_names(name):
     names = name.split(' ')
     return names[0] + ' ' + names[-1]
 
+
 def get_staff_hours_soonest_first():
     today = date.today()
-    
+
     def determine_hours_away(hour):
         now = 0
         hours_away_in_sec = 0
         time_as_string = hour.time
         day = hour.day
         day_diff = string_to_constant[day] - today.isoweekday()
-        now = dtime.now().strftime("%H:%M")
-        
+        now = dtime.now().strftime('%H:%M')
+
         def parse_time_string_no_am_pm(time):
             return convert_to_sec_from_day_start(time)
-        
+
         staff_hours_seconds = parse_time_string_with_am_pm(time_as_string)
-        today_time_in_sec =  parse_time_string_no_am_pm(now)
+        today_time_in_sec = parse_time_string_no_am_pm(now)
         earlier_in_day_or_earlier_in_week = day_diff < 0 \
-                or today.isoweekday() == string_to_constant[day] \
-                and staff_hours_seconds < today_time_in_sec 
+            or today.isoweekday() == string_to_constant[day] \
+            and staff_hours_seconds < today_time_in_sec
         if (earlier_in_day_or_earlier_in_week):
             day_diff += days_in_week
 
-        hours_away_in_sec += day_diff * seconds_in_day 
-        hours_away_in_sec += staff_hours_seconds - today_time_in_sec 
+        hours_away_in_sec += day_diff * seconds_in_day
+        hours_away_in_sec += staff_hours_seconds - today_time_in_sec
         return hours_away_in_sec
-        
 
     hours = chain.from_iterable([staff_day.hours for staff_day in get_staff_hours()])
-    hours = sorted(hours, key = lambda x: determine_hours_away(x))
+    hours = sorted(hours, key=lambda x: determine_hours_away(x))
     hours = [hour for hour in hours if not hour.cancelled]
-    hours_with_no_cancelled_hours = [hour for hour in hours if not date_is_holiday(hour.day)] 
+    hours_with_no_cancelled_hours = [hour for hour in hours if not date_is_holiday(hour.day)]
     return(hours_with_no_cancelled_hours)
-

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -99,6 +99,18 @@ def _remove_middle_names(name):
     return names[0] + ' ' + names[-1]
 
 
+def convert_to_sec_from_day_start(digital_time_string):
+    secs = 0
+    colon_index = digital_time_string.find(":")
+    if (colon_index != -1):
+        secs += int((digital_time_string[colon_index + 1:]).strip()) \
+                * seconds_in_a_min
+        secs += int((digital_time_string[:colon_index]).strip()) \
+                * seconds_in_a_hour
+        else:
+            secs += int((digital_time_string).strip()) * seconds_in_a_hour
+    return secs
+
 def get_staff_hours_soonest_first():
     today = date.today()
     def determine_hours_away(hour):


### PR DESCRIPTION
Goes along with pull request in ocfweb

Creates a new named-tuple Staffday, which holds all the staff hours on a single day (for example if Monday has staff hours 10-11, 11-12, 12-1, then Staffday will represent Monday and hold information about the the staff hours from 10-11, 11-12, 12-1, which are represented by the prexisting named tuple Hour).

Also added a feature that checks if a given day is a holiday (date_is_holiday) so that can be depicted on the staff hours webpage and cancels all the staff hours on that day without manually changing the yaml file. Updates at the end of each week instead of showing whether next occurrence of day is a holiday (for example if last Monday was a holiday and next Monday is not a holiday, but today is Saturday, then the staff-hours page would show the information about last Monday. However, if the today was a Sunday where last Monday was a holiday and next Monday(tomorrow) is not a holiday, then it would show the info for next Monday).

Lastly, improves upon the get_staff_hours_soonest_first method. Previously, this function would get the first two staff hours per day (but would still show these two staff hours if they had already passed or if they were canceled ). The alterations to this function will now show the next two staff hours that are not canceled. This is done by parsing the string that make up the staff hours by taking the end of the staff_hour (for example if staff hour is 9:30am-10:30am as listed in yaml file this function will use 10:30am), and converting into the number of seconds away from the current time the staff hour is. Then this function sorts the staff hours by seconds away. filters out the canceled staff hours, and displays the first two staff hours in the resulting list. 

 