### PR TITLE
happy hour spring 2018

### DIFF
--- a/ocflib/printing/quota.py
+++ b/ocflib/printing/quota.py
@@ -17,9 +17,10 @@ SEMESTERLY_QUOTA = 100
 #   - During breaks, Cabinet can make temporary changes to this quota.
 #   - At the next BoD meeting, BoD can ratify those temporary changes to make
 #     them permanent. If it doesn't, then those changes automatically expire.
+
 HAPPY_HOUR_QUOTA = 20
-HAPPY_HOUR_START = datetime(2017, 12, 4)
-HAPPY_HOUR_END = datetime(2017, 12, 17)
+HAPPY_HOUR_START = datetime(2018, 4, 30)
+HAPPY_HOUR_END = datetime(2018, 5, 13)
 
 
 get_connection = functools.partial(db.get_connection,

--- a/tests/printing/quota_test.py
+++ b/tests/printing/quota_test.py
@@ -53,8 +53,8 @@ TEST_REFUND = Refund(
     ('2015-08-26', WEEKDAY_QUOTA),  # Wednesday
     # Test "happy hour" quotas
     ('2017-12-01', WEEKDAY_QUOTA),
-    ('2017-12-07', HAPPY_HOUR_QUOTA),
-    ('2017-12-08', HAPPY_HOUR_QUOTA),
+    ('2018-04-30', HAPPY_HOUR_QUOTA),
+    ('2018-05-04', HAPPY_HOUR_QUOTA),
     ('2017-12-23', WEEKEND_QUOTA),
 ])
 def test_daily_quota(time, expected):


### PR DESCRIPTION
since we're not changing the quota, I don't believe a BoD vote
is necessary for this change. Presumably "Happy Hour" has some
pre-existing standing such that we don't need BoD approval
to enable it during the expected times it would be enabled.

At least, this is mine and @sahilhasan's understanding.