### PR TITLE
Add gapps_lists module

### DIFF
--- a/ocflib/misc/gapps_lists.py
+++ b/ocflib/misc/gapps_lists.py
@@ -1,0 +1,49 @@
+"""Google Admin Directory API for some mailing lists"""
+import googleapiclient.discovery
+from google.oauth2 import service_account
+
+
+class GAppsAdmin:
+    def __init__(self, service_account_file_path):
+        scopes = [
+            'https://www.googleapis.com/auth/admin.directory.group.member',
+        ]
+        credentials = service_account.Credentials.from_service_account_file(
+            service_account_file_path,
+            scopes=scopes,
+        )
+        delegated_credentials = credentials.with_subject(
+            'ocfbot@ocf.berkeley.edu'
+        )
+
+        self.groupadmin = googleapiclient.discovery.build(
+            'admin',
+            'directory_v1',
+            credentials=delegated_credentials,
+        )
+
+    def list_members(self, list_name):
+        """List all the OCF members (@ocf.berkeley.edu emails) in a GApps
+        mailing list. Strips email addresses, so this only returns email
+        addresses.
+
+        Ignores non-ocf.berkeley.edu emails and ocfbot@ocf.berkeley.edu.
+        """
+        response = self.groupadmin.members().list(groupKey=list_name).execute()
+        emails = (m['email'].split('@') for m in response['members'])
+
+        return [
+            username
+            for username, domain in emails
+            if domain == 'ocf.berkeley.edu'
+            if username != 'ocfbot'
+        ]
+
+    def add_to_list(self, email, list_name):
+        """Adds an email address to a Google mailing list."""
+        body = {'email': email}
+
+        self.groupadmin.members().insert(
+            groupKey=list_name,
+            body=body,
+        ).execute()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,10 @@
 coverage
 coveralls
 freezegun
+google-api-python-client
 ipdb
 mock
+oauth2client
 pre-commit
 pytest
 pytest-xdist

--- a/tests-manual/misc/list_officers
+++ b/tests-manual/misc/list_officers
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from ocflib.misc.gapps_lists import GAppsAdmin
+
+if __name__ == '__main__':
+    print('Enter path to service account credentials')
+    path = input('-> ')
+
+    admin = GAppsAdmin(path)
+
+    print('officers@ocf.berkeley.edu:')
+    print('\n'.join(admin.list_members('officers@ocf.berkeley.edu')))


### PR DESCRIPTION
This adds tools for interacting with our groups on GApps using the Google Admin API, and should lay the groundwork for eventually syncing LDAP groups and Google Groups.

One thing I'm not sure about in this commit is the way I handle authentication. My current plan is to have the credentials file get saved in the Puppet private share, and then have scripts provide that filename when constructing a `GAppsAdmin` object. But if there's a more idiomatic way to do this, I'd like to change it.