### PR TITLE
Switch to using a declarative Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,94 +1,78 @@
-try {
-    node('slave') {
-        step([$class: 'WsCleanup'])
+def dists = ['jessie', 'stretch', 'buster']
 
-        stage('check-out-code') {
-            dir('src') {
-                checkout scm
-            }
-        }
+def parallelStagesMap = dists.collectEntries {
+  ["${it}" : generateStage(it)]
+}
 
-        withCredentials([[
-            $class: 'StringBinding',
-            credentialsId: 'coveralls_token',
-            variable: 'COVERALLS_REPO_TOKEN'
-        ]]) {
-            stage('test') {
-                dir('src') {
-                    sh 'make coveralls'
-                }
-            }
-        }
-
-        stash 'src'
+def generateStage(dist) {
+  return {
+    stage("build-${dist}") {
+      sh 'make clean'
+      sh "make package_${dist}"
+      archiveArtifacts artifacts: "dist_${dist}/*"
     }
-
 
     if (env.BRANCH_NAME == 'master') {
-        node('deploy') {
-            step([$class: 'WsCleanup'])
-            unstash 'src'
-
-            stage('push-to-pypi') {
-                dir('src') {
-                    sh 'make release-pypi'
-                }
-            }
+      node('deploy') {
+        stage("upload-${dist}") {
+          uploadChanges(dist, "dist_${dist}/*.changes")
         }
+      }
+    }
+  }
+}
+
+pipeline {
+  agent {
+    label 'slave'
+  }
+
+  options {
+    ansiColor('xterm')
+    timeout(time: 1, unit: 'HOURS')
+  }
+
+  stages {
+    stage('test') {
+      environment {
+        COVERALLS_REPO_TOKEN = credentials('coveralls_token')
+      }
+      steps {
+        sh 'make coveralls'
+      }
     }
 
+    stage('push-to-pypi') {
+      when {
+        branch 'master'
+      }
+      agent {
+        label 'deploy'
+      }
+      steps {
+        sh 'make release-pypi'
+      }
+    }
 
-    def dists = ['jessie', 'stretch']
-    def branches = [:]
-
-    for (def i = 0; i < dists.size(); i++) {
-        def dist = dists[i]
-        branches["build-and-deploy-${dist}"] = {
-            stage("build-${dist}") {
-                node('slave') {
-                    step([$class: 'WsCleanup'])
-                    unstash 'src'
-
-                    dir('src') {
-                        sh 'make clean'
-                        sh "make package_${dist}"
-                        sh "mv dist dist_${dist}"
-                        archiveArtifacts artifacts: "dist_${dist}/*"
-                    }
-
-                    stash 'src'
-                }
-            }
-
-            if (env.BRANCH_NAME == 'master') {
-                stage("upload-${dist}") {
-                    build job: 'upload-changes', parameters: [
-                        [$class: 'StringParameterValue', name: 'path_to_changes', value: "dist_${dist}/*.changes"],
-                        [$class: 'StringParameterValue', name: 'dist', value: dist],
-                        [$class: 'StringParameterValue', name: 'job', value: env.JOB_NAME.replace('/', '/job/')],
-                        [$class: 'StringParameterValue', name: 'job_build_number', value: env.BUILD_NUMBER],
-                    ]
-                }
-            }
+    stage('parallel-builds') {
+      steps {
+        script {
+          parallel parallelStagesMap
         }
+      }
     }
-    parallel branches
+  }
 
-} catch (err) {
-    def subject = "${env.JOB_NAME} - Build #${env.BUILD_NUMBER} - Failure!"
-    def message = "${env.JOB_NAME} (#${env.BUILD_NUMBER}) failed: ${env.BUILD_URL}"
-
-    if (env.BRANCH_NAME == 'master') {
-        slackSend color: '#FF0000', message: message
-        mail to: 'root@ocf.berkeley.edu', subject: subject, body: message
-    } else {
-        mail to: emailextrecipients([
-            [$class: 'CulpritsRecipientProvider'],
-            [$class: 'DevelopersRecipientProvider']
-        ]), subject: subject, body: message
+  post {
+    failure {
+      emailNotification()
     }
-
-    throw err
+    always {
+      node(label: 'slave') {
+        ircNotification()
+      }
+    }
+  }
 }
 
 // vim: ft=groovy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,12 @@ pipeline {
   }
 
   stages {
+    stage('check-gh-trust') {
+      steps {
+        checkGitHubAccess()
+      }
+    }
+
     stage('test') {
       environment {
         COVERALLS_REPO_TOKEN = credentials('coveralls_token')

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ release-pypi: clean autoversion
 	twine upload dist/*
 
 .PHONY: builddeb
-
 builddeb: autoversion
 	dpkg-buildpackage -us -uc
 
@@ -37,9 +36,9 @@ dist:
 	mkdir -p "$@"
 
 .PHONY: clean
-clean: autoversion
+clean:
 	python3 setup.py clean
-	rm -rf dist deb_dist
+	rm -rf dist deb_dist dist_*
 
 # PEP440 sets terrible restrictions on public version schemes which prohibit:
 #   - appending a SHA

--- a/build-in-docker
+++ b/build-in-docker
@@ -12,4 +12,5 @@ mk-build-deps -i --tool 'apt-get --no-install-recommends -y'
 make builddeb
 
 shopt -s nullglob
-install -o "$DIST_UID" -g "$DIST_GID" -m 644 ../{*.changes,*.deb,*.dsc,*.tar.*,*.buildinfo} /mnt/dist/
+install -o "$DIST_UID" -g "$DIST_GID" -d "/mnt/dist_$1/"
+install -o "$DIST_UID" -g "$DIST_GID" -m 644 ../{*.changes,*.deb,*.dsc,*.tar.*,*.buildinfo} "/mnt/dist_$1/"


### PR DESCRIPTION
This is much cleaner, hopefully it works the same way. I'm mostly concerned about some of the parallel stuff at the top, as I'm not sure if I've done it correctly. This is in a similar vein to ocf/dns#20, I eventually hope to have everything migrated to using this kind of format (and using the shared stuff in our [shared pipeline](https://github.com/ocf/shared-pipeline)).

I think this is probably the most complicated Jenkinsfile we have (due to all the parallel building stuff mostly), so after this is done I think migrating the other repos will be reasonably straightforward.