### PR TITLE
Test if non-contributors can trigger custom builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,12 @@
 try {
     node('slave') {
         step([$class: 'WsCleanup'])
+        
+        stage('test-command') {
+            dir('src') {
+                sh 'ls'
+            }
+        }
 
         stage('check-out-code') {
             dir('src') {


### PR DESCRIPTION
Would be an remote code execution if so, but Jenkins should protect against some of this (changing the Jenkinsfile specifically)

(actually made by @jvperrin)