### PR TITLE
Fix coverage when using pytest-xdist

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
 branch = True
+source = ocflib,tests
 
 [report]
+show_missing = true
 include = ocflib/*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
-coverage
 coveralls
 freezegun
 ipdb
 mock
 pre-commit
 pytest
+pytest-cov
 pytest-xdist
 twine

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,7 @@ venv_update =
         install= -r {toxinidir}/requirements-dev.txt -e {toxinidir}
 commands =
     {[testenv]venv_update}
-    coverage erase
-    coverage run --source=ocflib,tests -m pytest -n auto -v tests
-    coverage report --show-missing
+    py.test --cov --cov-report=term-missing -n auto -v tests
     pre-commit run --all-files
 
 [flake8]


### PR DESCRIPTION
`pytest-cov` works with `pytest-xdist` whereas `coverage` does not, so this should fix the coveralls reports that we have 0% coverage and start reporting correct values again.