### PR TITLE
Monkeypatch out checking for affiliation, as berkeleyEduAffiliations …

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -260,11 +260,12 @@ def validate_calnet_uid(uid):
     if not attrs:
         raise ValidationError("CalNet UID can't be found in university LDAP.")
 
+    # TODO: Uncomment when we get privileged LDAP bind.
     # check if user is eligible for an account
-    affiliations = attrs['berkeleyEduAffiliations']
-    if not eligible_for_account(affiliations):
-        raise ValidationWarning(
-            'Affiliate type not eligible for account: ' + str(affiliations))
+    # affiliations = attrs['berkeleyEduAffiliations']
+    # if not eligible_for_account(affiliations):
+    #    raise ValidationWarning(
+    #        'Affiliate type not eligible for account: ' + str(affiliations))
 
 
 def eligible_for_account(affiliations):

--- a/ocflib/vhost/web.py
+++ b/ocflib/vhost/web.py
@@ -87,7 +87,8 @@ def eligible_for_vhost(user):
         return True
     elif 'calnetUid' in attrs:
         attrs_ucb = user_attrs_ucb(attrs['calnetUid'])
-        if attrs_ucb and 'EMPLOYEE-TYPE-ACADEMIC' in attrs_ucb['berkeleyEduAffiliations']:
+        # TODO: Uncomment when we get a privileged LDAP bind.
+        if attrs_ucb:  # and 'EMPLOYEE-TYPE-ACADEMIC' in attrs_ucb['berkeleyEduAffiliations']:
             return True
 
     return False

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -276,6 +276,7 @@ class TestAccountEligibility:
     def test_validate_calnet_uid_success(self, mock_valid_calnet_uid):
         validate_calnet_uid(9999999999999)
 
+    @pytest.mark.skip(reason='Checking for affiliations temp. patched out (ocflib PR 140)')
     def test_validate_calnet_affiliations_failure(self, mock_invalid_calnet_uid):
         with pytest.raises(ValidationWarning):
             validate_calnet_uid(9999999999999)


### PR DESCRIPTION
…is being [removed](https://calnetweb.berkeley.edu/calnet-technologists/ldap-directory-service/changes-anonymous-ldap-binds-1012018) from anonymous LDAP searches.

please let me know if i missed anything for account creation that uses this attribute