### PR TITLE
Add timeouts to requests

### DIFF
--- a/ocflib/infra/discourse.py
+++ b/ocflib/infra/discourse.py
@@ -25,9 +25,11 @@ class DiscourseTopic(namedtuple('DiscourseTopic', ('number', 'title', 'starter',
     def from_number(cls, api_key, num):
         params = {'api_key': api_key, 'api_username': 'gstaff'}
 
-        topic_resp = requests.get('{}/t/{}.json'.format(DISCOURSE_ROOT, num),
-                                  params=params
-                                  )
+        topic_resp = requests.get(
+            '{}/t/{}.json'.format(DISCOURSE_ROOT, num),
+            params=params,
+            timeout=10,
+        )
         if topic_resp.status_code != 200:
             raise DiscourseError(
                 'Topic request gave {}'.format(topic_resp.status_code)
@@ -37,9 +39,11 @@ class DiscourseTopic(namedtuple('DiscourseTopic', ('number', 'title', 'starter',
 
         category_id = topic['category_id']
 
-        cat_resp = requests.get('{}/categories.json'.format(DISCOURSE_ROOT),
-                                params=params,
-                                )
+        cat_resp = requests.get(
+            '{}/categories.json'.format(DISCOURSE_ROOT),
+            params=params,
+            timeout=10,
+        )
         if cat_resp.status_code != 200:
             raise DiscourseError(
                 'Category request gave {}'.format(cat_resp.status_code)

--- a/ocflib/infra/mesos/marathon.py
+++ b/ocflib/infra/mesos/marathon.py
@@ -38,7 +38,7 @@ class MarathonClient:
         return req
 
     def app_status(self, app):
-        req = self.get('/v2/apps/' + app)
+        req = self.get('/v2/apps/' + app, timeout=20)
         return req.json()
 
     def deploy_app(
@@ -66,6 +66,7 @@ class MarathonClient:
         self.put(
             '/v2/apps/' + app + ('?force=true' if force else ''),
             json=new_config,
+            timeout=20,
         )
 
         # wait for deployment to finish, report status
@@ -80,7 +81,7 @@ class MarathonClient:
                 time.sleep(1)
         else:
             bad_deployment, = status['app']['deployments']
-            self.delete('/v2/deployments/' + bad_deployment['id'])
+            self.delete('/v2/deployments/' + bad_deployment['id'], timeout=20)
             raise DeploymentException(
                 'Gave up waiting for deployment {} after {} seconds.\n'
                 'Automatically rolling back.'.format(

--- a/ocflib/infra/rt.py
+++ b/ocflib/infra/rt.py
@@ -45,6 +45,7 @@ def rt_connection(user, password):
     resp = s.post(
         'https://rt.ocf.berkeley.edu/REST/1.0/',
         data=urlencode({'user': user, 'pass': password}),
+        timeout=20,
     )
     assert resp.status_code == 200, resp.status_code
     assert '200 Ok' in resp.text

--- a/ocflib/lab/hours.py
+++ b/ocflib/lab/hours.py
@@ -44,7 +44,7 @@ def _generate_regular_hours():
 
     regular_hours = {}
 
-    for day, hours in requests.get(HOURS_URL).json().items():
+    for day, hours in requests.get(HOURS_URL, timeout=20).json().items():
         regular_hours[int(day)] = [
             Hour(
                 open=_parsetime(hour[0]),

--- a/ocflib/lab/staff_hours.py
+++ b/ocflib/lab/staff_hours.py
@@ -36,7 +36,7 @@ def _load_staff_hours():
             return yaml.safe_load(f)
     except IOError:
         # fall back to loading from web
-        return yaml.safe_load(requests.get(STAFF_HOURS_URL).text)
+        return yaml.safe_load(requests.get(STAFF_HOURS_URL, timeout=20).text)
 
 
 def get_staff_hours():

--- a/ocflib/ucb/cas.py
+++ b/ocflib/ucb/cas.py
@@ -13,11 +13,12 @@ def verify_ticket(ticket, service):
     Returns CalNet UID on success and None on failure.
     """
     params = {'ticket': ticket, 'service': service}
-    url = (urljoin(CAS_URL, 'serviceValidate') + '?' +
-           urlencode(params))
+    url = urljoin(CAS_URL, 'serviceValidate') + '?' + urlencode(params)
+
     try:
-        req = requests.get(url)
+        req = requests.get(url, timeout=30)
         tree = ElementTree.fromstring(req.text)
+
         if tree[0].tag.endswith('authenticationSuccess'):
             return tree[0][0].text
         else:

--- a/ocflib/ucb/groups.py
+++ b/ocflib/ucb/groups.py
@@ -147,7 +147,7 @@ def _get_osl(query, service, parser):
 
     url = '{}/{}?{}'.format(_API['BASE'], service, urlencode(query))
 
-    r = requests.get(url)
+    r = requests.get(url, timeout=20)
     return _parse_osl(ElementTree.fromstring(r.text), parser)
 
 

--- a/ocflib/vhost/application.py
+++ b/ocflib/vhost/application.py
@@ -14,7 +14,7 @@ def get_app_vhost_db():
             return f.read().splitlines()
     except IOError:
         # fallback to database loaded from web
-        return requests.get(VHOST_DB_URL).text.split('\n')
+        return requests.get(VHOST_DB_URL, timeout=20).text.split('\n')
 
 
 def get_app_vhosts():

--- a/ocflib/vhost/mail.py
+++ b/ocflib/vhost/mail.py
@@ -73,7 +73,7 @@ def get_mail_vhost_db():
             return list(map(str.strip, f))
     except IOError:
         # fallback to database loaded from web
-        return requests.get(VHOST_MAIL_DB_URL).text.split('\n')
+        return requests.get(VHOST_MAIL_DB_URL, timeout=20).text.split('\n')
 
 
 def get_mail_vhosts():

--- a/ocflib/vhost/web.py
+++ b/ocflib/vhost/web.py
@@ -17,7 +17,7 @@ def get_vhost_db():
             return f.read().splitlines()
     except IOError:
         # fallback to database loaded from web
-        return requests.get(VHOST_DB_URL).text.split('\n')
+        return requests.get(VHOST_DB_URL, timeout=20).text.split('\n')
 
 
 def get_vhosts():


### PR DESCRIPTION
I added timeouts to all the places I could find that requests were made, since the default timeout with requests is an unlimited amount of time. This causes undesirable behavior in some places, such as making ocfweb workers get killed off due to hitting the 30 second default timeout in gunicorn.