### PR TITLE
Allow LDAP changes without a keytab

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -19,7 +19,7 @@ import ocflib.account.utils as utils
 import ocflib.account.validators as validators
 from ocflib.infra.kerberos import create_kerberos_principal_with_keytab
 from ocflib.infra.kerberos import get_kerberos_principal_with_keytab
-from ocflib.infra.ldap import create_ldap_entry_with_keytab
+from ocflib.infra.ldap import create_ldap_entry
 from ocflib.infra.ldap import ldap_ocf
 from ocflib.infra.ldap import OCF_LDAP_PEOPLE
 from ocflib.misc.mail import jinja_mail_env
@@ -126,8 +126,11 @@ def create_account(request, creds, report_status, known_uid=_KNOWN_UID):
             attrs['callinkOid'] = request.callink_oid
 
         with report_status('Creating', 'Created', 'LDAP entry'):
-            create_ldap_entry_with_keytab(
-                dn, attrs, creds.kerberos_keytab, creds.kerberos_principal,
+            create_ldap_entry(
+                dn,
+                attrs,
+                keytab=creds.kerberos_keytab,
+                admin_principal=creds.kerberos_principal,
             )
 
             # invalidate passwd cache so that we can immediately chown files

--- a/ocflib/account/manage.py
+++ b/ocflib/account/manage.py
@@ -86,7 +86,7 @@ def change_password_with_keytab(username, password, keytab, principal, comment=N
     _notify_password_change(username, comment=comment)
 
 
-def modify_ldap_attributes(username, attributes, keytab, principal):
+def modify_ldap_attributes(username, attributes, **kwargs):
     """Adds or modifies arbitrary attributes of a user's LDAP record subject to
     minor validation beyond the LDAP schema.
 
@@ -98,11 +98,10 @@ def modify_ldap_attributes(username, attributes, keytab, principal):
         if not misc.validators.valid_login_shell(value):
             raise ValueError("Invalid login shell '{}'".format(value))
 
-    ldap_ocf.modify_ldap_entry_with_keytab(
+    ldap_ocf.modify_ldap_entry(
         utils.dn_for_username(username),
         attributes,
-        keytab,
-        principal,
+        **kwargs,
     )
 
 

--- a/ocflib/account/submission.py
+++ b/ocflib/account/submission.py
@@ -47,7 +47,6 @@ from ocflib.account.creation import NewAccountRequest
 from ocflib.account.creation import send_rejected_mail
 from ocflib.account.creation import validate_request
 from ocflib.account.manage import change_password_with_keytab
-from ocflib.account.manage import modify_ldap_attributes as real_modify_ldap_attributes
 
 
 Base = declarative_base()
@@ -334,22 +333,6 @@ def get_tasks(celery_app, credentials=None):
         )
 
     @celery_app.task
-    def modify_ldap_attributes(username, attributes):
-        """Modify the ldap attributes of a username.
-
-        Validation is applied for e.g. the 'mail' and 'loginShell' fields, but
-        this operation is not guaranteed to be safe.
-
-        :param attributes: dictionary of attribute names and values
-        """
-        real_modify_ldap_attributes(
-            username=username,
-            attributes=attributes,
-            keytab=credentials.kerberos_keytab,
-            principal=credentials.kerberos_principal,
-        )
-
-    @celery_app.task
     def status():
         """A testing route."""
         return {
@@ -364,7 +347,6 @@ def get_tasks(celery_app, credentials=None):
         approve_request=approve_request,
         reject_request=reject_request,
         change_password=change_password,
-        modify_ldap_attributes=modify_ldap_attributes,
         status=status,
     )
 
@@ -376,7 +358,6 @@ _AccountSubmissionTasks = namedtuple('AccountSubmissionTasks', [
     'approve_request',
     'reject_request',
     'change_password',
-    'modify_ldap_attributes',
     'status',
 ])
 

--- a/tests-manual/infra/create-ldap-keytab
+++ b/tests-manual/infra/create-ldap-keytab
@@ -2,13 +2,13 @@
 from datetime import datetime
 from datetime import timezone
 
-from ocflib.infra.ldap import create_ldap_entry_with_keytab
+from ocflib.infra.ldap import create_ldap_entry
 
 
 # Run with:
 #   sudo /path/to/ocflib/venv/bin/python3 create-ldap-keytab
 if __name__ == '__main__':
-    create_ldap_entry_with_keytab(
+    create_ldap_entry(
         'uid=ggroup2,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
         {
             'objectClass': ['ocfAccount', 'account', 'posixAccount'],
@@ -20,6 +20,6 @@ if __name__ == '__main__':
             'gidNumber': 1000,
             'creationTime': datetime.now(timezone.utc).astimezone(),
         },
-        '/etc/ocf-create/create.keytab',
-        'create/admin',
+        keytab='/etc/ocf-create/create.keytab',
+        admin_principal='create/admin',
     )

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -537,7 +537,7 @@ class TestCreateAccount:
         with mock.patch('ocflib.account.creation.create_kerberos_principal_with_keytab') as kerberos, \
                 mock.patch('ocflib.account.creation.get_kerberos_principal_with_keytab',
                            return_value=None) as kerberos_get, \
-                mock.patch('ocflib.account.creation.create_ldap_entry_with_keytab') as ldap, \
+                mock.patch('ocflib.account.creation.create_ldap_entry') as ldap, \
                 mock.patch('ocflib.account.creation.create_home_dir') as home_dir, \
                 mock.patch('ocflib.account.creation.ensure_web_dir') as web_dir, \
                 mock.patch('ocflib.account.creation.send_created_mail') as send_created_mail, \
@@ -582,8 +582,8 @@ class TestCreateAccount:
                     'userPassword': '{SASL}someuser@OCF.BERKELEY.EDU',
                     'creationTime': datetime.now(timezone.utc).astimezone(),
                 }, **expected),
-                fake_credentials.kerberos_keytab,
-                fake_credentials.kerberos_principal,
+                keytab=fake_credentials.kerberos_keytab,
+                admin_principal=fake_credentials.kerberos_principal,
             )
             call.assert_called_once_with(('sudo', 'nscd', '-i', 'passwd'))
             home_dir.assert_called_once_with(fake_new_account_request.user_name)

--- a/tests/account/manage_test.py
+++ b/tests/account/manage_test.py
@@ -22,19 +22,11 @@ def mock_notify_password_change():
 
 
 @pytest.yield_fixture
-def mock_create_ldap_entry_with_keytab():
+def mock_modify_ldap_entry():
     with mock.patch(
-        'ocflib.infra.ldap.create_ldap_entry_with_keytab',
-    ) as create_ldap_entry_with_keytab:
-        yield create_ldap_entry_with_keytab
-
-
-@pytest.yield_fixture
-def mock_modify_ldap_entry_with_keytab():
-    with mock.patch(
-        'ocflib.infra.ldap.modify_ldap_entry_with_keytab',
-    ) as modify_ldap_entry_with_keytab:
-        yield modify_ldap_entry_with_keytab
+        'ocflib.infra.ldap.modify_ldap_entry',
+    ) as modify_ldap_entry:
+        yield modify_ldap_entry
 
 
 class TestChangePasswordWithStaffer:
@@ -106,33 +98,33 @@ class TestChangePasswordWithKeytab:
 
 class TestModifyLdapAttributes:
 
-    def test_success(self, mock_modify_ldap_entry_with_keytab):
+    def test_success(self, mock_modify_ldap_entry):
         modify_ldap_attributes(
             'ggroup',
             {'a': ('b', 'c'), 'loginShell': ('/bin/bash',)},
-            '/some/keytab',
-            'create/admin',
+            keytab='/some/keytab',
+            admin_principal='create/admin',
         )
-        mock_modify_ldap_entry_with_keytab.assert_called_once_with(
+        mock_modify_ldap_entry.assert_called_once_with(
             'uid=ggroup,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
             {'a': ('b', 'c'), 'loginShell': ('/bin/bash',)},
-            '/some/keytab',
-            'create/admin',
+            keytab='/some/keytab',
+            admin_principal='create/admin',
         )
 
     @pytest.mark.parametrize('attrs', [
         {'loginShell': ['/bin/bush']},
         {'loginShell': ['']},
     ])
-    def test_invalid_attributes(self, attrs, mock_modify_ldap_entry_with_keytab):
+    def test_invalid_attributes(self, attrs, mock_modify_ldap_entry):
         with pytest.raises(ValueError):
             modify_ldap_attributes(
                 'ggroup',
                 attrs,
-                '/some/keytab',
-                'create/admin',
+                keytab='/some/keytab',
+                admin_principal='create/admin',
             )
-        assert not mock_modify_ldap_entry_with_keytab.called
+        assert not mock_modify_ldap_entry.called
 
 
 class TestNotifyPasswordChange:

--- a/tests/account/submission_test.py
+++ b/tests/account/submission_test.py
@@ -311,14 +311,3 @@ def test_change_password(tasks, fake_credentials):
             keytab=fake_credentials.kerberos_keytab,
             comment='comment',
         )
-
-
-def test_modify_ldap_attributes(tasks, fake_credentials):
-    with mock.patch('ocflib.account.submission.real_modify_ldap_attributes') as m:
-        tasks.modify_ldap_attributes('ggroup', {'a': ['b', 'c'], 'd': ['e']})
-        m.assert_called_once_with(
-            username='ggroup',
-            attributes={'a': ['b', 'c'], 'd': ['e']},
-            keytab=fake_credentials.kerberos_keytab,
-            principal=fake_credentials.kerberos_principal,
-        )

--- a/tests/infra/ldap_test.py
+++ b/tests/infra/ldap_test.py
@@ -1,26 +1,20 @@
-from base64 import b64encode
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from subprocess import CalledProcessError
+from textwrap import dedent
 
 import mock
 import pytest
 
-from ocflib.infra.ldap import create_ldap_entry_with_keytab
-from ocflib.infra.ldap import modify_ldap_entry_with_keytab
-
-
-def encode(attr, value):
-    return '{attr}:: {value}'.format(
-        attr=attr,
-        value=b64encode(value.encode('utf8')).decode('ascii'),
-    )
+from ocflib.infra.ldap import create_ldap_entry
+from ocflib.infra.ldap import modify_ldap_entry
 
 
 @pytest.yield_fixture
-def mock_spawn():
-    with mock.patch('pexpect.spawn') as spawn:
-        yield spawn
+def mock_subprocess_check_output():
+    with mock.patch('subprocess.check_output') as check_output:
+        yield check_output
 
 
 @pytest.yield_fixture
@@ -31,100 +25,154 @@ def mock_send_problem_report():
 
 class TestCreateLdapEntry:
 
-    def test_normal_creation(self, mock_spawn, mock_send_problem_report):
-        mock_spawn.return_value.before = b'\n'
-        create_ldap_entry_with_keytab(
+    def test_normal_creation(self, mock_subprocess_check_output, mock_send_problem_report):
+        create_ldap_entry(
             'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
-            {'a': ['b', 'c'], 'd': 12, 'e': datetime(2016, 11, 5, 12, 0, 0, tzinfo=timezone(timedelta(hours=-7)))},
-            '/nonexist',
-            'create/admin',
+            {'a': ['b', 'c']},
         )
 
-        mock_spawn.assert_called_with(
-            'kinit -t /nonexist create/admin ldapmodify',
+        # These are the base64-encoded versions of the attributes above
+        ldif = dedent("""
+            dn:: dWlkPWNrdWVobCxvdT1QZW9wbGUsZGM9T0NGLGRjPUJlcmtlbGV5LGRjPUVEVQ==
+            changetype: add
+            a:: Yg==
+            a:: Yw==
+        """).strip()
+
+        mock_subprocess_check_output.assert_called_with(
+            ('/usr/bin/ldapmodify', '-Q'),
+            input=ldif,
+            universal_newlines=True,
             timeout=10,
         )
-        mock_spawn.return_value.expect.assert_has_calls([
-            mock.call('SASL data security layer installed.'),
-            mock.call('entry "uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU"'),
-        ])
 
-        mock_spawn.return_value.sendline.assert_has_calls([
-            mock.call(encode(attr, value))
-            for attr, value in [
-                ('dn', 'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU'),
-                ('a', 'b'),
-                ('a', 'c'),
-                ('d', '12'),
-                ('e', '20161105120000-0700'),
-            ]
-        ] + [mock.call('changetype: add')], any_order=True)
-        assert mock_spawn.return_value.sendeof.called
         assert not mock_send_problem_report.called
 
-    def test_create_existing(self, mock_spawn, mock_send_problem_report):
-        mock_spawn.return_value.before = b'\nAlready exists (68)\n'
-        with pytest.raises(ValueError):
-            create_ldap_entry_with_keytab(
-                'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
-                {'a': ['b', 'c'], 'd': ['e']},
-                '/nonexist',
-                'create/admin',
-            )
+    def test_normal_creation_keytab(self, mock_subprocess_check_output, mock_send_problem_report):
+        create_ldap_entry(
+            'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
+            {'a': ['b', 'c'], 'd': 12, 'e': datetime(2016, 11, 5, 12, 0, 0, tzinfo=timezone(timedelta(hours=-7)))},
+            keytab='/nonexist',
+            admin_principal='create/admin',
+        )
+
+        # These are the base64-encoded versions of the attributes above
+        ldif = dedent("""
+            dn:: dWlkPWNrdWVobCxvdT1QZW9wbGUsZGM9T0NGLGRjPUJlcmtlbGV5LGRjPUVEVQ==
+            changetype: add
+            a:: Yg==
+            a:: Yw==
+            d:: MTI=
+            e:: MjAxNjExMDUxMjAwMDAtMDcwMA==
+        """).strip()
+
+        mock_subprocess_check_output.assert_called_with(
+            ('/usr/bin/kinit', '-t', '/nonexist', 'create/admin', '/usr/bin/ldapmodify', '-Q'),
+            input=ldif,
+            universal_newlines=True,
+            timeout=10,
+        )
+
         assert not mock_send_problem_report.called
 
-    def test_unexpected_error(self, mock_spawn, mock_send_problem_report):
-        mock_spawn.return_value.before = b'\nlol wut is this error\n'
-        with pytest.raises(ValueError):
-            create_ldap_entry_with_keytab(
+    def test_create_existing(self, mock_subprocess_check_output, mock_send_problem_report):
+        mock_subprocess_check_output.side_effect = CalledProcessError(68, 'cmd', output='Already exists (68)')
+        with pytest.raises(ValueError) as error:
+            create_ldap_entry(
                 'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
                 {'a': ['b', 'c'], 'd': ['e']},
-                '/nonexist',
-                'create/admin',
             )
+        assert 'Tried to create duplicate entry.' in error.value.args
+        assert not mock_send_problem_report.called
+
+    def test_unexpected_error(self, mock_subprocess_check_output, mock_send_problem_report):
+        mock_subprocess_check_output.side_effect = CalledProcessError(35, 'cmd', output='lol random error')
+        with pytest.raises(ValueError) as error:
+            create_ldap_entry(
+                'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
+                {'a': ['b', 'c'], 'd': ['e']},
+            )
+        assert 'Unknown LDAP failure was encountered.' in error.value.args
         assert mock_send_problem_report.called
+
+    def test_error_without_timezone(self, mock_subprocess_check_output):
+        with pytest.raises(ValueError) as error:
+            create_ldap_entry(
+                'uid=ckuehl,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
+                {'datetime': datetime(2016, 11, 5, 12, 0, 0)},
+            )
+        assert 'Timestamp has no timezone info' in error.value.args
+        assert mock_subprocess_check_output.assert_not_called
 
 
 class TestModifyLdapEntry:
 
-    def test_normal_modification(self, mock_spawn, mock_send_problem_report):
-        mock_spawn.return_value.before = b'\n'
-        modify_ldap_entry_with_keytab(
+    def test_normal_modification(self, mock_subprocess_check_output, mock_send_problem_report):
+        modify_ldap_entry(
             'uid=mattmcal,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
             {'a': ['b', 'c'], 'calnetUid': 1234},
-            '/nonexist',
-            'create/admin'
         )
 
-        mock_spawn.assert_called_with(
-            'kinit -t /nonexist create/admin ldapmodify',
+        # These are the base64-encoded versions of the attributes above
+        ldif = dedent("""
+            dn:: dWlkPW1hdHRtY2FsLG91PVBlb3BsZSxkYz1PQ0YsZGM9QmVya2VsZXksZGM9RURV
+            changetype: modify
+            replace: a
+            a:: Yg==
+            a:: Yw==
+            -
+            replace: calnetUid
+            calnetUid:: MTIzNA==
+            -
+        """).strip()
+
+        mock_subprocess_check_output.assert_called_with(
+            ('/usr/bin/ldapmodify', '-Q'),
+            input=ldif,
+            universal_newlines=True,
             timeout=10,
         )
-        mock_spawn.return_value.expect.assert_has_calls([
-            mock.call('SASL data security layer installed.'),
-            mock.call('entry "uid=mattmcal,ou=People,dc=OCF,dc=Berkeley,dc=EDU"'),
-        ])
 
-        mock_spawn.return_value.sendline.assert_has_calls((
-            mock.call(encode('dn', 'uid=mattmcal,ou=People,dc=OCF,dc=Berkeley,dc=EDU')),
-            mock.call('changetype: modify'),
-            mock.call('replace: a'),
-            mock.call(encode('a', 'b')),
-            mock.call(encode('a', 'c')),
-            mock.call('-'),
-            mock.call('replace: calnetUid'),
-            mock.call(encode('calnetUid', '1234')),
-        ), any_order=True)
-        assert mock_spawn.return_value.sendeof.called
         assert not mock_send_problem_report.called
 
-    def test_modify_nonexistent(self, mock_spawn, mock_send_problem_report):
-        mock_spawn.return_value.before = b'\nNo such object (32)\n'
-        with pytest.raises(ValueError):
-            modify_ldap_entry_with_keytab(
+    def test_normal_modification_keytab(self, mock_subprocess_check_output, mock_send_problem_report):
+        modify_ldap_entry(
+            'uid=mattmcal,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
+            {'a': ['b', 'c'], 'calnetUid': 1234},
+            keytab='/nonexist',
+            admin_principal='create/admin'
+        )
+
+        # These are the base64-encoded versions of the attributes above
+        ldif = dedent("""
+            dn:: dWlkPW1hdHRtY2FsLG91PVBlb3BsZSxkYz1PQ0YsZGM9QmVya2VsZXksZGM9RURV
+            changetype: modify
+            replace: a
+            a:: Yg==
+            a:: Yw==
+            -
+            replace: calnetUid
+            calnetUid:: MTIzNA==
+            -
+        """).strip()
+
+        mock_subprocess_check_output.assert_called_with(
+            ('/usr/bin/kinit', '-t', '/nonexist', 'create/admin', '/usr/bin/ldapmodify', '-Q'),
+            input=ldif,
+            universal_newlines=True,
+            timeout=10,
+        )
+
+        assert not mock_send_problem_report.called
+
+    def test_modify_nonexistent(self, mock_subprocess_check_output, mock_send_problem_report):
+        mock_subprocess_check_output.side_effect = CalledProcessError(32, 'cmd', output='No such object (32)')
+        with pytest.raises(ValueError) as error:
+            modify_ldap_entry(
                 'uid=unknown,ou=People,dc=OCF,dc=Berkeley,dc=EDU',
                 {'a': ['b', 'c'], 'd': ['e']},
-                '/nonexist',
-                'create/admin'
+                keytab='/nonexist',
+                admin_principal='create/admin'
             )
+        assert 'Tried to modify nonexistent entry.' in error.value.args
         assert not mock_send_problem_report.called


### PR DESCRIPTION
This then allows these functions to be used in user-facing scripts where they have potentially already authenticated with their password and have an existing Kerberos ticket. (like in `update-email` and `chsh`, the [two remaining python2 scripts](https://github.com/ocf/utils/issues/19) we have)

I also did a pretty major refactor to use `subprocess` instead of `pexpect` for changing LDAP since ldapmodify can just accept input from stdin instead of needing it to be passed in interactively. I also removed a celery task for modifying LDAP attributes that isn't used anywhere outside of ocflib as far as I could tell with sourcegraph.

I tested this manually with `./tests-manual/infra/create-ldap-keytab` and that worked fine, along with manually testing in a console that I could change my `loginShell` and `mail` attributes without a keytab being passed in.