### PR TITLE
kill ocflib package builds for jessie

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ packagePipeline(
     coverallsToken: 'coveralls_ocflib_token',
     pypiRelease: true,
     // TODO: Add back the build for buster when it works without perl errors
-    dists: ['jessie', 'stretch'],
+    dists: ['stretch'],
 )
 
 // vim: ft=groovy

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ builddeb: autoversion
 	dpkg-buildpackage -us -uc
 
 .PHONY: package
-package: package_jessie package_stretch
+package: package_stretch
 
 .PHONY: package_%
 package_%: dist


### PR DESCRIPTION
the only jessie machine we have left is slated to die soon and building this package takes up more time than everything else combined in the jenkins pipeline