### PR TITLE
Add new hours2 api

### DIFF
--- a/ocflib/lab/hours2.py
+++ b/ocflib/lab/hours2.py
@@ -1,0 +1,289 @@
+"""Methods for dealing with OCF lab hours.
+
+All times are assumed to be OST (OCF Standard Time).
+
+Usage:
+
+    >>> from ocflib.lab.hours2 import read_hours_listing()
+    >>> hours_listing = read_hours_listing()
+    >>> hours_listing.hours_on_date(date(2015-10-12))
+    [Hour(open=datetime.time(9, 0), close=datetime.time(18, 0))]
+"""
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from enum import IntEnum
+
+import attr
+import yaml
+
+
+class Weekday(IntEnum):
+    Monday = 0
+    Tuesday = 1
+    Wednesday = 2
+    Thursday = 3
+    Friday = 4
+    Saturday = 5
+    Sunday = 6
+
+
+def _parsetime(t):
+    if isinstance(t, time):
+        return t
+
+    return datetime.strptime(t, '%H:%M').time()
+
+
+def _parse_regular_hours(regular):
+    """Parses a dictionary of regular hours, as used in the yaml file.
+
+    Keys can be either weekday strings ("Monday", "Tuesday", ...) or Weekday
+    enums. Values should be a list of timeranges, parseable by
+    _parse_hours_list.
+    """
+    out = {}
+    for weekday, hours in regular.items():
+        try:
+            # First see if it's an int already
+            weekday = Weekday(weekday)
+        except ValueError:
+            # Convert strings ('Monday') to int (0)
+            weekday = getattr(Weekday, weekday)
+
+        out[weekday] = _parse_hours_list(hours)
+
+    if out.keys() != set(Weekday):
+        raise ValueError('Regular hours must be set for all weekdays')
+
+    return out
+
+
+def _parse_hours_list(time_ranges):
+    """Converts a list of timeranges to a list of Hour objects.
+
+    This function idempotently does nothing on a list of Hour objects.
+
+    Raises an ValueError if the timeranges overlap.
+
+    >>> _parse_hours_list([['8:30', '10:00'], ['11:00', '3:00']])
+    [Hour(time(8, 30), time(10)), Hour(time(11), time(3))]
+
+    >>> _parse_hours_list([['8:30', '10:00'], ['9:00', '11:00']])
+    Traceback (most recent call last):
+        ...
+    ValueError: Hours must be in order
+
+    >>> _parse_hours_list([['8:30', '10:00'], ['8:00', '11:00']])
+    Traceback (most recent call last):
+        ...
+    ValueError: Hours must be in order
+    """
+    hours = []
+
+    for hour in time_ranges:
+        if not isinstance(hour, Hour):
+            hour = Hour(hour[0], hour[1])
+
+        if hours and hours[-1].close > hour.open:
+            raise ValueError('Hours must be in order')
+
+        hours.append(hour)
+
+    return hours
+
+
+def _parse_holiday(holiday):
+    """Converts a holiday dict to a Holiday object.
+
+    This function idempotently does nothing on a Holiday object.
+    """
+    if isinstance(holiday, Holiday):
+        return holiday
+
+    if isinstance(holiday['date'], list):
+        start, end = holiday['date']
+    elif isinstance(holiday['date'], date):
+        start = end = holiday['date']
+    else:
+        raise ValueError(
+            'Holiday date is not a (start, end) pair or single datetime'
+        )
+
+    return Holiday(
+        reason=holiday['reason'],
+        startdate=start,
+        enddate=end,
+        hours=holiday.get('hours', []),
+    )
+
+
+def _parse_holiday_list(holidays):
+    """Converts a list of holiday dicts to a list of Holiday objects.
+
+    This function idempotently does nothing on a list of Holiday objects.
+
+    Raises a ValueError if the dateranges overlap.
+    """
+    out = []
+
+    for holiday in holidays:
+        holiday = _parse_holiday(holiday)
+        if out and out[-1].enddate >= holiday.startdate:
+            raise ValueError('Holiday dateranges must not overlap')
+
+        out.append(holiday)
+
+    return out
+
+
+@attr.s(frozen=True)
+class HoursListing(object):
+    regular = attr.ib(converter=_parse_regular_hours)
+    holidays = attr.ib(converter=_parse_holiday_list)
+
+    def hours_on_date(self, when=None):
+        """Returns the hours on the given date.
+
+        If not provided, when defaults to today.
+        """
+        if not when:
+            when = date.today()
+
+        if not isinstance(when, date):
+            raise ValueError('{} must be a datetime instance'.format(when))
+
+        # check if it's a holiday
+        for holiday in self.holidays:
+            if holiday.startdate <= when <= holiday.enddate:
+                return holiday.hours
+
+        return self.regular[when.weekday()]
+
+    def is_open(self, when=None):
+        """Return whether the lab is open at the given datetime.
+
+        If not provided, when defaults to now.
+        """
+        if not when:
+            when = datetime.now()
+
+        if not isinstance(when, datetime):
+            raise ValueError('{} must be a datetime instance'.format(when))
+
+        return any(
+            when.time() in hour
+            for hour in self.hours_on_date(when.date())
+        )
+
+    def time_to_open(self, when=None):
+        """Return timedelta object representing time until the lab is open from the given datetime.
+
+        If the lab will never be open, returns None.
+
+        If not provided, when defaults to now.
+        """
+        if not when:
+            when = datetime.now()
+
+        if not isinstance(when, datetime):
+            raise ValueError('{} must be a datetime instance'.format(when))
+
+        if self.is_open(when=when):
+            return timedelta()
+
+        on_date = when.date()
+
+        # Loop until the end of the last holiday plus 8 days
+        if self.holidays:
+            last_holiday = self.holidays[-1].enddate
+        else:
+            last_holiday = on_date
+
+        while on_date < max(when.date(), last_holiday) + timedelta(days=8):
+            future_hours = self.hours_on_date(on_date)
+            for hour in future_hours:
+                time_to_open = datetime.combine(on_date, hour.open) - when
+                if time_to_open >= timedelta():
+                    return time_to_open
+
+            on_date += timedelta(days=1)
+
+        return None
+
+    def time_to_close(self, when=None):
+        """Return timedelta object representing time until the lab is closed from the given datetime.
+
+        If the lab will never close, returns None.
+
+        If not provided, when defaults to now.
+        """
+        if not when:
+            when = datetime.now()
+
+        if not isinstance(when, datetime):
+            raise ValueError('{} must be a datetime instance'.format(when))
+
+        if not self.is_open(when=when):
+            return timedelta()
+
+        on_date = when.date()
+
+        # Loop until the end of the last holiday plus 8 days
+        if self.holidays:
+            last_holiday = self.holidays[-1].enddate
+        else:
+            last_holiday = on_date
+
+        while on_date < max(when.date(), last_holiday) + timedelta(days=8):
+            future_hours = self.hours_on_date(on_date)
+            for hour in future_hours:
+                time_to_close = datetime.combine(on_date, hour.close) - when
+                if time_to_close >= timedelta():
+                    return time_to_close
+
+            on_date += timedelta(days=1)
+
+        return None
+
+
+@attr.s(frozen=True)
+class Holiday(object):
+    reason = attr.ib(validator=[attr.validators.instance_of(str)])
+    startdate = attr.ib(validator=[attr.validators.instance_of(date)])
+    enddate = attr.ib(validator=[attr.validators.instance_of(date)])
+    hours = attr.ib(converter=_parse_hours_list)
+
+    @enddate.validator
+    def _valid_enddate(self, attribute, value):
+        if value < self.startdate:
+            raise ValueError('Holiday dateranges must be valid')
+
+
+@attr.s(frozen=True)
+class Hour(object):
+    open = attr.ib(
+        validator=[attr.validators.instance_of(time)],
+        converter=_parsetime,
+    )
+    close = attr.ib(
+        validator=[attr.validators.instance_of(time)],
+        converter=_parsetime,
+    )
+
+    def __contains__(self, when):
+        if not isinstance(when, time):
+            raise ValueError('{} must be a time instance'.format(when))
+        return self.open <= when < self.close
+
+    @close.validator
+    def _valid_closetime(self, attribute, value):
+        if value <= self.open:
+            raise ValueError('Hour timerange must be valid')
+
+
+def read_hours_listing():
+    hours_config = yaml.safe_load(open('/etc/ocf/configs/hours.yaml'))
+
+    return HoursListing(**hours_config)

--- a/ocflib/lab/hours2.py
+++ b/ocflib/lab/hours2.py
@@ -45,10 +45,9 @@ def _parse_regular_hours(regular):
     """
     out = {}
     for weekday, hours in regular.items():
-        try:
-            # First see if it's an int already
+        if isinstance(weekday, int):
             weekday = Weekday(weekday)
-        except ValueError:
+        else:
             # Convert strings ('Monday') to int (0)
             weekday = getattr(Weekday, weekday)
 
@@ -108,7 +107,7 @@ def _parse_holiday(holiday):
         start = end = holiday['date']
     else:
         raise ValueError(
-            'Holiday date is not a (start, end) pair or single datetime'
+            'Holiday date is not a [start, end] pair or single datetime'
         )
 
     return Holiday(
@@ -148,7 +147,7 @@ class HoursListing(object):
 
         If not provided, when defaults to today.
         """
-        if not when:
+        if when is None:
             when = date.today()
 
         if not isinstance(when, date):
@@ -166,7 +165,7 @@ class HoursListing(object):
 
         If not provided, when defaults to now.
         """
-        if not when:
+        if when is None:
             when = datetime.now()
 
         if not isinstance(when, datetime):
@@ -184,7 +183,7 @@ class HoursListing(object):
 
         If not provided, when defaults to now.
         """
-        if not when:
+        if when is None:
             when = datetime.now()
 
         if not isinstance(when, datetime):
@@ -219,7 +218,7 @@ class HoursListing(object):
 
         If not provided, when defaults to now.
         """
-        if not when:
+        if when is None:
             when = datetime.now()
 
         if not isinstance(when, datetime):

--- a/ocflib/lab/hours2.py
+++ b/ocflib/lab/hours2.py
@@ -49,7 +49,7 @@ def _parse_regular_hours(regular):
             weekday = Weekday(weekday)
         else:
             # Convert strings ('Monday') to int (0)
-            weekday = getattr(Weekday, weekday)
+            weekday = Weekday[weekday]
 
         out[weekday] = _parse_hours_list(hours)
 

--- a/ocflib/lab/hours2.py
+++ b/ocflib/lab/hours2.py
@@ -64,7 +64,7 @@ def _parse_hours_list(time_ranges):
 
     This function idempotently does nothing on a list of Hour objects.
 
-    Raises an ValueError if the timeranges overlap.
+    Raises an ValueError if the timeranges overlap or are out of order.
 
     >>> _parse_hours_list([['8:30', '10:00'], ['11:00', '3:00']])
     [Hour(time(8, 30), time(10)), Hour(time(11), time(3))]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,10 @@
+attrs
 coveralls
 freezegun
 ipdb
 mock
 pre-commit
+pyfakefs
 pytest
 pytest-cov
 pytest-xdist

--- a/tests/lab/hours2_test.py
+++ b/tests/lab/hours2_test.py
@@ -1,0 +1,189 @@
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+
+import pytest
+from freezegun import freeze_time
+
+from ocflib.lab.hours2 import Holiday
+from ocflib.lab.hours2 import Hour
+from ocflib.lab.hours2 import HoursListing
+from ocflib.lab.hours2 import read_hours_listing
+from ocflib.lab.hours2 import Weekday
+
+
+FAKE_HOURS_YAML = '''
+regular:
+  Monday:
+    - ['9:00', '18:00']
+  Tuesday:
+    - ['9:00', '18:00']
+  Wednesday:
+    - ['9:10', '18:00']
+  Thursday:
+    - ['9:00', '12:00']
+    - ['14:00', '18:00']
+  Friday:
+    - ['9:00', '18:00']
+  Saturday:
+    - ['11:00', '18:00']
+  Sunday:
+    - ['12:00', '17:00']
+holidays:
+  - date: 2015-03-14
+    reason: Pi Day
+  - date: [2015-03-20, 2015-03-22]
+    reason: Random 3 Days
+    hours:
+      - ['1:00', '2:00']
+  - date: [2015-12-19, 2016-01-18]
+    reason: Winter Break
+'''
+
+EMPTY_REGULAR_HOURS = dict(zip(Weekday, [[]] * 7))
+FAKE_NOW = datetime(2015, 8, 22, 14, 11)
+
+
+@pytest.fixture
+def mock_hours_yaml(fs):
+    fs.create_file('/etc/ocf/configs/hours.yaml', contents=FAKE_HOURS_YAML)
+
+
+@pytest.fixture
+def mock_now():
+    with freeze_time(FAKE_NOW):
+        yield
+
+
+@pytest.mark.parametrize('now,expected_hours', [
+    # regular hours
+    (date(2015, 3, 13), [Hour(open=time(9), close=time(18))]),
+    (None, [Hour(open=time(11), close=time(18))]),
+
+    # holidays
+    (date(2015, 3, 14), []),
+    (date(2015, 3, 19), [
+        Hour(open=time(9), close=time(12)),
+        Hour(open=time(14), close=time(18)),
+    ]),
+    (date(2015, 3, 20), [Hour(open=time(1), close=time(2))]),
+    (date(2015, 3, 21), [Hour(open=time(1), close=time(2))]),
+    (date(2015, 3, 22), [Hour(open=time(1), close=time(2))]),
+    (date(2015, 3, 23), [Hour(open=time(9), close=time(18))]),
+])
+def test_hours_on_date(now, expected_hours, mock_hours_yaml, mock_now):
+    assert read_hours_listing().hours_on_date(now) == expected_hours
+
+
+@pytest.mark.parametrize('now,expected_open', [
+    # regular hours
+    (datetime(2015, 3, 15, 12), True),
+    (datetime(2015, 3, 19, 17), True),
+    (datetime(2015, 3, 19, 9), True),
+    (datetime(2015, 3, 19, 18), False),
+    (datetime(2015, 3, 19, 0), False),
+    (None, True),
+
+    # holidays
+    (datetime(2015, 3, 14, 12), False),
+    (datetime(2015, 3, 14, 0), False),
+    (datetime(2015, 3, 20, 0), False),
+    (datetime(2015, 3, 20, 1), True),
+    (datetime(2015, 3, 20, 1, 30), True),
+    (datetime(2015, 3, 20, 1, 59), True),
+    (datetime(2015, 3, 20, 2, 0), False),
+])
+def test_is_open(now, expected_open, mock_hours_yaml, mock_now):
+    assert read_hours_listing().is_open(now) == expected_open
+
+
+@pytest.mark.parametrize('now,expected_next_open', [
+    (datetime(2015, 1, 5, 8), datetime(2015, 1, 5, 9)),
+    (datetime(2015, 1, 6, 19), datetime(2015, 1, 7, 9, 10)),
+    (datetime(2015, 1, 8, 8), datetime(2015, 1, 8, 9)),
+    (datetime(2015, 1, 8, 13), datetime(2015, 1, 8, 14)),
+    (datetime(2015, 1, 8, 19), datetime(2015, 1, 9, 9)),
+
+    # Pi Day
+    (datetime(2015, 3, 13, 19), datetime(2015, 3, 15, 12)),
+    (datetime(2015, 3, 14, 9), datetime(2015, 3, 15, 12)),
+    (datetime(2015, 3, 14, 12), datetime(2015, 3, 15, 12)),
+    (datetime(2015, 3, 14, 19), datetime(2015, 3, 15, 12)),
+
+    # Random 3 Days
+    (datetime(2015, 3, 19, 19), datetime(2015, 3, 20, 1)),
+    (datetime(2015, 3, 20, 0), datetime(2015, 3, 20, 1)),
+    (datetime(2015, 3, 20, 3), datetime(2015, 3, 21, 1)),
+    (datetime(2015, 3, 22, 3), datetime(2015, 3, 23, 9)),
+
+    # Winter Break
+    (datetime(2015, 12, 18, 21), datetime(2016, 1, 19, 9)),
+    (datetime(2015, 12, 19, 12), datetime(2016, 1, 19, 9)),
+    (datetime(2016, 1, 18, 12), datetime(2016, 1, 19, 9)),
+
+    # Far in the future
+    (datetime(2500, 3, 1, 21), datetime(2500, 3, 2, 9)),
+])
+def test_time_to_open(now, expected_next_open, mock_hours_yaml):
+    hours_listing = read_hours_listing()
+    assert hours_listing.time_to_open(now) == expected_next_open - now
+    assert hours_listing.time_to_close(now) == timedelta()
+
+
+@pytest.mark.parametrize('now,expected_next_close', [
+    (datetime(2015, 1, 5, 10), datetime(2015, 1, 5, 18)),
+    (datetime(2015, 1, 8, 10), datetime(2015, 1, 8, 12)),
+    (datetime(2015, 1, 8, 15), datetime(2015, 1, 8, 18)),
+
+    # Random 3 Days
+    (datetime(2015, 3, 20, 1, 30), datetime(2015, 3, 20, 2)),
+
+    # Far in the future
+    (datetime(2500, 3, 1, 10), datetime(2500, 3, 1, 18)),
+])
+def test_time_to_close(now, expected_next_close, mock_hours_yaml):
+    hours_listing = read_hours_listing()
+    assert hours_listing.time_to_close(now) == expected_next_close - now
+    assert hours_listing.time_to_open(now) == timedelta()
+
+
+def test_time_to_close_now(mock_hours_yaml, mock_now):
+    hours_listing = read_hours_listing()
+    assert hours_listing.time_to_open() == timedelta()
+    assert hours_listing.time_to_close() == datetime(2015, 8, 22, 18) - FAKE_NOW
+
+
+def test_no_hours():
+    # Pray that this never comes to pass 🙏🙏🙏
+    hours_listing = HoursListing(regular=EMPTY_REGULAR_HOURS, holidays=[])
+    assert hours_listing.time_to_close() == timedelta()
+    assert hours_listing.time_to_open() is None
+
+
+@pytest.mark.parametrize('startdate,enddate,hours', [
+    (date(2015, 2, 3), date(2015, 2, 2), []),
+    (
+        date(2015, 2, 2),
+        date(2015, 2, 3),
+        [Hour(time(10), time(12)), Hour(time(11), time(14))],
+    ),
+    (
+        date(2015, 2, 2),
+        date(2015, 2, 3),
+        [Hour(time(10), time(12)), Hour(time(8), time(14))],
+    ),
+    (
+        date(2015, 2, 2),
+        date(2015, 2, 3),
+        [Hour(time(10), time(12)), Hour(time(8), time(9))],
+    ),
+])
+def test_invalid_holiday(startdate, enddate, hours):
+    with pytest.raises(ValueError):
+        Holiday(reason='', startdate=startdate, enddate=enddate, hours=hours)
+
+
+def test_idempotence(mock_hours_yaml):
+    hours_listing = read_hours_listing()
+    assert hours_listing == HoursListing(**vars(hours_listing))


### PR DESCRIPTION
This adds a new API for getting lab hours. The plan is to deprecate the old API and replace it with this one. In the meantime there will have to be an "`hours`" and "`hour2`".

This API is a bit nicer because it stores the entire hours listing in a single object, and methods on that object work on the entire calendar. This is better than our current system since it makes it easier to cache hours for ocfweb.

This also reads hours from a yaml file (in etc) instead of being part of the library itself. I also used the `attrs` library for nice validation and conversion from YAML to object types.