### PR TITLE
Migrate from autopep8-wrapper to mirrors-autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,8 @@
 exclude: ^vendor/
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    sha: v0.9.5
+    rev: v2.1.0
     hooks:
-    -   id: autopep8-wrapper
     -   id: check-added-large-files
     -   id: check-docstring-first
     -   id: check-executables-have-shebangs
@@ -22,21 +21,25 @@ repos:
     -   id: requirements-txt-fixer
     -   id: sort-simple-yaml
     -   id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.3
+    hooks:
+    -   id: autopep8
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: '3.7.3'
+    rev: 3.7.7
     hooks:
     - id: flake8
       language_version: python3.5
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    sha: v0.3.5
+    rev: v1.4.0
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/asottile/pyupgrade.git
-    sha: v1.2.0
+    rev: v1.12.0
     hooks:
     -   id: pyupgrade
         args: ['--py3-plus']
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
-    sha: v1.1.1
+    rev: v1.1.6
     hooks:
     -   id: remove-tabs

--- a/ocflib/lab/hours.py
+++ b/ocflib/lab/hours.py
@@ -138,7 +138,7 @@ def _parse_holiday_list(holidays):
 
 
 @attr.s(frozen=True)
-class HoursListing(object):
+class HoursListing:
     regular = attr.ib(converter=_parse_regular_hours)
     holidays = attr.ib(converter=_parse_holiday_list)
 
@@ -248,7 +248,7 @@ class HoursListing(object):
 
 
 @attr.s(frozen=True)
-class Holiday(object):
+class Holiday:
     reason = attr.ib(validator=[attr.validators.instance_of(str)])
     startdate = attr.ib(validator=[attr.validators.instance_of(date)])
     enddate = attr.ib(validator=[attr.validators.instance_of(date)])
@@ -261,7 +261,7 @@ class Holiday(object):
 
 
 @attr.s(frozen=True)
-class Hour(object):
+class Hour:
     open = attr.ib(
         validator=[attr.validators.instance_of(time)],
         converter=_parsetime,

--- a/ocflib/misc/validators.py
+++ b/ocflib/misc/validators.py
@@ -1,7 +1,6 @@
 """Misc validators for things like emails, domains, etc."""
 import re
 
-import dns
 import dns.resolver
 
 from ocflib.infra.net import OCF_DNS_RESOLVER


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos