### PR TITLE
Revert "add `mastodon` to validators.py"

### DIFF
--- a/ocflib/account/validators.py
+++ b/ocflib/account/validators.py
@@ -116,7 +116,6 @@ RESERVED_USERNAMES = frozenset((
     'man',
     'manager',
     'marketing',
-    'mastodon',
     'memcache',
     'mesos',
     'messagebus',


### PR DESCRIPTION
Reverts ocf/ocflib#173, the commit was failing to build