### PR TITLE
Fix the happyhour rule

### DIFF
--- a/ocflib/printing/quota.py
+++ b/ocflib/printing/quota.py
@@ -62,7 +62,7 @@ def daily_quota(day=None):
     if day is None:
         day = datetime.today()
 
-    if HAPPY_HOUR_START <= day and day < HAPPY_HOUR_END:
+    if HAPPY_HOUR_START <= day and day <= HAPPY_HOUR_END:
         return HAPPY_HOUR_QUOTA
     elif day.weekday() in {5, 6}:
         return WEEKEND_QUOTA

--- a/tests/printing/quota_test.py
+++ b/tests/printing/quota_test.py
@@ -54,7 +54,7 @@ TEST_REFUND = Refund(
     # Test "happy hour" quotas
     ('2017-12-01', WEEKDAY_QUOTA),
     ('2019-5-6', HAPPY_HOUR_QUOTA),
-    ('2019-5-16', HAPPY_HOUR_QUOTA),
+    ('2019-5-17', HAPPY_HOUR_QUOTA),
     ('2017-12-23', WEEKEND_QUOTA),
 ])
 def test_daily_quota(time, expected):


### PR DESCRIPTION
A more humane way to represent when the double quota days end.
And so that people will have 20 pages today.