### PR TITLE
Add printing adjustments

### DIFF
--- a/ocflib/printing/ocfprinting.sql
+++ b/ocflib/printing/ocfprinting.sql
@@ -165,4 +165,4 @@ CREATE VIEW `public_jobs` AS
     ORDER BY `day` DESC
 
 GRANT SELECT ON `ocfprinting`.`printed` TO 'anonymous'@'%';
-GRANT SELECT on `ocfprinting`.`public_jobs` TO 'anonymous'@'%';
+GRANT SELECT ON `ocfprinting`.`public_jobs` TO 'anonymous'@'%';

--- a/ocflib/printing/ocfprinting.sql
+++ b/ocflib/printing/ocfprinting.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `adjustments` (
     `id` int NOT NULL AUTO_INCREMENT,
     `user` varchar(255) NOT NULL,
     `time` datetime NOT NULL,
-    `action` varchar(255) NOT NULL,
+    `action` enum('refund', 'forward'),
     `pages` int NOT NULL,
     `staffer` varchar(255) NOT NULL,
     `reason` varchar(510) NOT NULL,

--- a/ocflib/printing/ocfprinting.sql
+++ b/ocflib/printing/ocfprinting.sql
@@ -16,10 +16,11 @@ CREATE TABLE IF NOT EXISTS `jobs` (
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
-CREATE TABLE IF NOT EXISTS `refunds` (
+CREATE TABLE IF NOT EXISTS `adjustments` (
     `id` int NOT NULL AUTO_INCREMENT,
     `user` varchar(255) NOT NULL,
     `time` datetime NOT NULL,
+    `action` varchar(255) NOT NULL,
     `pages` int NOT NULL,
     `staffer` varchar(255) NOT NULL,
     `reason` varchar(510) NOT NULL,
@@ -27,7 +28,7 @@ CREATE TABLE IF NOT EXISTS `refunds` (
 ) ENGINE=InnoDB;
 
 CREATE INDEX `jobs_idx` ON `jobs` (`user`, `time`, `pages`);
-CREATE INDEX `refunds_idx` ON `refunds` (`user`, `time`, `pages`);
+CREATE INDEX `refunds_idx` ON `adjustments` (`user`, `time`, `action`, `pages`);
 
 DROP FUNCTION IF EXISTS semester_start;
 DELIMITER $$
@@ -52,29 +53,57 @@ CREATE VIEW jobs_today AS
 DROP VIEW IF EXISTS refunds_today;
 CREATE VIEW refunds_today AS
     SELECT user, SUM(pages) AS pages
-    FROM refunds
-    WHERE DATE(refunds.time) = CURDATE()
+    FROM adjustments
+    WHERE DATE(adjustments.time) = CURDATE()
+    AND action = "refund"
+    GROUP BY user;
+
+DROP VIEW IF EXISTS forwards_today;
+CREATE VIEW forwards_today AS
+    SELECT user, SUM(pages) AS pages
+    FROM adjustments
+    WHERE DATE(adjustments.time) = CURDATE()
+    AND action = "forward"
     GROUP BY user;
 
 DROP VIEW IF EXISTS printed_today;
 CREATE VIEW `printed_today` AS
     SELECT
         jobs_today.user AS user,
-        COALESCE(jobs_today.pages, 0) - COALESCE(refunds_today.pages, 0) AS today
+        COALESCE(jobs_today.pages, 0) - COALESCE(refunds_today.pages, 0)
+          - COALESCE(forwards_today.pages, 0) AS today
     FROM jobs_today
     LEFT OUTER JOIN refunds_today
     ON jobs_today.user = refunds_today.user
+    LEFT OUTER JOIN forwards_today
+    ON jobs_today.user = forwards_today.user
     GROUP BY jobs_today.user
 
     UNION
 
     SELECT
         refunds_today.user AS user,
-        COALESCE(jobs_today.pages, 0) - COALESCE(refunds_today.pages, 0) AS today
-    FROM jobs_today
-    RIGHT OUTER JOIN refunds_today
-    ON jobs_today.user = refunds_today.user
+        COALESCE(jobs_today.pages, 0) - COALESCE(refunds_today.pages, 0)
+          - COALESCE(forwards_today.pages, 0) AS today
+    FROM refunds_today
+    LEFT OUTER JOIN jobs_today
+    ON refunds_today.user = jobs_today.user
+    LEFT OUTER JOIN forwards_today
+    ON refunds_today.user = forwards_today.user
     GROUP BY refunds_today.user
+
+    UNION
+
+    SELECT
+        forwards_today.user AS user,
+        COALESCE(jobs_today.pages, 0) - COALESCE(refunds_today.pages, 0)
+          - COALESCE(forwards_today.pages, 0) AS today
+    FROM forwards_today
+    LEFT OUTER JOIN jobs_today
+    ON forwards_today.user = jobs_today.user
+    LEFT OUTER JOIN refunds_today
+    ON forwards_today.user = refunds_today.user
+    GROUP BY forwards_today.user
 
     ORDER BY user;
 
@@ -88,8 +117,9 @@ CREATE VIEW jobs_semester AS
 DROP VIEW IF EXISTS refunds_semester;
 CREATE VIEW refunds_semester AS
     SELECT user, SUM(pages) AS pages
-    FROM refunds
-    WHERE DATE(refunds.time) >= semester_start(CURDATE())
+    FROM adjustments
+    WHERE DATE(adjustments.time) >= semester_start(CURDATE())
+    AND action = "refund"
     GROUP BY user;
 
 DROP VIEW IF EXISTS printed_semester;
@@ -107,9 +137,9 @@ CREATE VIEW `printed_semester` AS
     SELECT
         refunds_semester.user AS user,
         COALESCE(jobs_semester.pages, 0) - COALESCE(refunds_semester.pages, 0) AS semester
-    FROM jobs_semester
-    RIGHT OUTER JOIN refunds_semester
-    ON jobs_semester.user = refunds_semester.user
+    FROM refunds_semester
+    LEFT OUTER JOIN jobs_semester
+    ON refunds_semester.user = jobs_semester.user
     GROUP BY refunds_semester.user
 
     ORDER BY user;

--- a/ocflib/printing/quota.py
+++ b/ocflib/printing/quota.py
@@ -45,10 +45,11 @@ Job = namedtuple('Job', (
     'filesize',
 ))
 
-Refund = namedtuple('Refund', (
+Payload = namedtuple('Payload', (
     'user',
     'time',
     'pages',
+    'action'
     'staffer',
     'reason',
 ))
@@ -117,6 +118,6 @@ def add_job(c, job):
     c.execute(*_namedtuple_to_query('INSERT INTO jobs ({}) VALUES ({})', job))
 
 
-def add_refund(c, refund):
+def add_adjustment(c, payload):
     """Add a new refund to the database."""
-    c.execute(*_namedtuple_to_query('INSERT INTO refunds ({}) VALUES ({})', refund))
+    c.execute(*_namedtuple_to_query('INSERT INTO adjustments ({}) VALUES ({})', payload))

--- a/ocflib/printing/quota.py
+++ b/ocflib/printing/quota.py
@@ -119,5 +119,5 @@ def add_job(c, job):
 
 
 def add_adjustment(c, payload):
-    """Add a new refund to the database."""
+    """Add a new adjustment to the database (either refund or forward)."""
     c.execute(*_namedtuple_to_query('INSERT INTO adjustments ({}) VALUES ({})', payload))


### PR DESCRIPTION
Depended on by ocf/utils#114

Allows staff members to adjust users' paper quotas in a more flexible manner.

We add the following functionality to the `paper` script:
`forward`:  increases a user's daily quota for the day only

This is intended to be used to give users some degree of freedom when printing documents.

For example, if the daily print limit was set at `10` pages and a user wanted to print `12` pages, this would not be possible with the current way things are configured. `forward` provides the way to increase the daily print limit without increasing the amount of pages a user can print in a semester.