### PR TITLE
account creation: set new ocfEmail attribute

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -132,6 +132,7 @@ def create_account(request, creds, report_status, known_uid=_KNOWN_UID):
             'gidNumber': getgrnam('ocf').gr_gid,
             'homeDirectory': utils.home_dir(request.user_name),
             'loginShell': '/bin/bash',
+            'ocfEmail': request.user_name + '@ocf.berkeley.edu',
             'mail': [request.email],
             'userPassword': '{SASL}' + request.user_name + '@OCF.BERKELEY.EDU',
             'creationTime': datetime.now(timezone.utc).astimezone(),

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -596,6 +596,7 @@ class TestCreateAccount:
                     'uidNumber': 42,
                     'homeDirectory': '/home/s/so/someuser',
                     'loginShell': '/bin/bash',
+                    'ocfEmail': 'someuser@ocf.berkeley.edu',
                     'mail': ['some.user@ocf.berkeley.edu'],
                     'userPassword': '{SASL}someuser@OCF.BERKELEY.EDU',
                     'creationTime': datetime.now(timezone.utc).astimezone(),


### PR DESCRIPTION
When I call `ocflib.account.search.user_attrs('dkessler')` this attr shows up as a single string, not a list containing a single string, so I'm pretty sure this is the right way to do it.