### PR TITLE
reserve all current mailing list aliases

### DIFF
--- a/ocflib/account/validators.py
+++ b/ocflib/account/validators.py
@@ -265,9 +265,10 @@ RESERVED_USERNAMES = frozenset((
     'techtalks',
     'todo',
 
-    # Mailing lists and legacy mailing lists
+    # Mailing lists, aliases, and legacy mailing lists
     'abuse',
     'alums',
+    'alumnus',
     'announce',
     'decal',
     'decal-announce',
@@ -276,6 +277,8 @@ RESERVED_USERNAMES = frozenset((
     'jenkins',
     'joinstaff',
     'mirrors',
+    'manager',
+    'managers',
     'mon',
     'munin',
     'officers',
@@ -288,6 +291,7 @@ RESERVED_USERNAMES = frozenset((
     'root',
     'rt',
     'rt-ops',
+    'sks',
     'sm',
     'staff',
     'wheel',


### PR DESCRIPTION
I noticed that alumni@ was a mailing list and also a user, which prompted me to check that all the mailing lists were reserved. See also ocf/puppet#780 and ocf/puppet#783