### PR TITLE
Fix domain-related test

### DIFF
--- a/tests/misc/validators_test.py
+++ b/tests/misc/validators_test.py
@@ -20,7 +20,7 @@ FAKE_HOSTS = [
     'i am not a real host',
     'lashdfkjashgklhsadfsad.com',
     'asdfghjkl.eecs.berkeley.edu',
-    'asdfghjkl.berkeley.edu',
+    'non-existent-domain.berkeley.edu',
     'kljasdlgjlsafdfhsadf.berkeley.edu',
     'jf0194y89v(*#14o1i9XC',
     '@I$)!($U)!#Y%!)#()*(%!#',


### PR DESCRIPTION
Also see https://github.com/ocf/ocfweb/pull/571 where this needed to be fixed in ocfweb earlier today. Ultimately I think not reaching out to DNS and mocking the response would be a better practice so we're not dependent on the return values of the university's DNS (or even whether it's available or not).

I ran `make test` locally to verify it worked, but the tests on this review should also pass.