### PR TITLE
Update vhost config locations to use /etc/ocf

### DIFF
--- a/ocflib/vhost/application.py
+++ b/ocflib/vhost/application.py
@@ -1,20 +1,12 @@
 import re
 
-import requests
-
-VHOST_DB_PATH = '/home/s/st/staff/vhost/vhost-app.conf'
-VHOST_DB_URL = 'https://www.ocf.berkeley.edu/~staff/vhost-app.conf'
+VHOST_DB_PATH = '/etc/ocf/vhost-app.conf'
 
 
 def get_app_vhost_db():
-    """Returns lines from the application vhost database. Loaded from the
-    filesystem (if available), or from the web if not."""
-    try:
-        with open(VHOST_DB_PATH) as f:
-            return f.read().splitlines()
-    except IOError:
-        # fallback to database loaded from web
-        return requests.get(VHOST_DB_URL, timeout=20).text.split('\n')
+    """Returns lines from the application vhost config file."""
+    with open(VHOST_DB_PATH) as f:
+        return f.read().splitlines()
 
 
 def get_app_vhosts():

--- a/ocflib/vhost/mail.py
+++ b/ocflib/vhost/mail.py
@@ -2,13 +2,11 @@ import crypt
 import functools
 from collections import namedtuple
 
-import requests
 from cached_property import cached_property
 
 from ocflib.infra import mysql
 
-VHOST_MAIL_DB_PATH = '/home/s/st/staff/vhost/vhost-mail.conf'
-VHOST_MAIL_DB_URL = 'https://www.ocf.berkeley.edu/~staff/vhost-mail.conf'
+VHOST_MAIL_DB_PATH = '/etc/ocf/vhost-mail.conf'
 
 get_connection = functools.partial(mysql.get_connection, db='ocfmail')
 
@@ -66,14 +64,9 @@ class MailForwardingAddress(namedtuple('MailForwardingAddress', (
 
 
 def get_mail_vhost_db():
-    """Returns lines from the vhost database. Loaded from the filesystem (if
-    available), or from the web if not."""
-    try:
-        with open(VHOST_MAIL_DB_PATH) as f:
-            return list(map(str.strip, f))
-    except IOError:
-        # fallback to database loaded from web
-        return requests.get(VHOST_MAIL_DB_URL, timeout=20).text.split('\n')
+    """Returns lines from the vhost config file."""
+    with open(VHOST_MAIL_DB_PATH) as f:
+        return list(map(str.strip, f))
 
 
 def get_mail_vhosts():

--- a/ocflib/vhost/web.py
+++ b/ocflib/vhost/web.py
@@ -1,23 +1,15 @@
 import re
 
-import requests
-
 from ocflib.account.search import user_attrs
 from ocflib.account.search import user_attrs_ucb
 
-VHOST_DB_PATH = '/home/s/st/staff/vhost/vhost.conf'
-VHOST_DB_URL = 'https://www.ocf.berkeley.edu/~staff/vhost.conf'
+VHOST_DB_PATH = '/etc/ocf/vhost.conf'
 
 
 def get_vhost_db():
-    """Returns lines from the vhost database. Loaded from the filesystem (if
-    available), or from the web if not."""
-    try:
-        with open(VHOST_DB_PATH) as f:
-            return f.read().splitlines()
-    except IOError:
-        # fallback to database loaded from web
-        return requests.get(VHOST_DB_URL, timeout=20).text.split('\n')
+    """Returns lines from the vhost config file."""
+    with open(VHOST_DB_PATH) as f:
+        return f.read().splitlines()
 
 
 def get_vhosts():

--- a/tests/vhost/web_test.py
+++ b/tests/vhost/web_test.py
@@ -55,22 +55,11 @@ def mock_get_vhosts_db():
 
 class TestVirtualHosts:
 
-    def test_reads_file_if_exists(self):
+    def test_reads_file(self):
         with mock.patch('builtins.open', mock.mock_open()) as mock_open:
             text = 'hello\nworld\n'
             mock_open.return_value.read.return_value = text
             assert get_vhost_db() == text.splitlines()
-
-    @mock.patch('builtins.open')
-    @mock.patch('requests.get')
-    def test_reads_web_if_no_file(self, get, mock_open):
-        def raise_error(__):
-            raise IOError()
-
-        mock_open.side_effect = raise_error
-        get.return_value.text = 'hello\nworld'
-
-        assert get_vhost_db() == ['hello', 'world']
 
     def test_proper_parse(self, mock_get_vhosts_db):
         assert get_vhosts() == VHOSTS_EXAMPLE_PARSED


### PR DESCRIPTION
This was added in ocf/etc#108 and should be present on every host, unlike the NFS-backed files previously. This should also remove the need for the web fallback path, so I've removed that. Conceivably we could use the web to fallback to requesting the files from github, but it seems at that point we should be notified that something is going wrong.