### PR TITLE
set max username length to 16

### DIFF
--- a/ocflib/account/utils.py
+++ b/ocflib/account/utils.py
@@ -40,7 +40,7 @@ def extract_username_from_principal(principal):
     'ckuehl'
     """
 
-    REGEX = '^([a-z]{3,8})(/[a-z]*)?@OCF\\.BERKELEY\\.EDU$'
+    REGEX = '^([a-z]{3,16})(/[a-z]*)?@OCF\\.BERKELEY\\.EDU$'
     match = re.match(REGEX, principal)
 
     if not match:


### PR DESCRIPTION
This was causing passwd to fail for usernames longer than 8 chars.