### PR TITLE
Create PRs for vhosts programmatically

### DIFF
--- a/ocflib/infra/github.py
+++ b/ocflib/infra/github.py
@@ -1,0 +1,53 @@
+from github import Github
+from github import InputGitTreeElement
+
+OCF_GITHUB_ORG = 'ocf'
+
+
+class GithubCredentials():
+    """Basic class to store Github credentials and verify input"""
+
+    def __init__(self, username=None, password=None, token=None):
+        if (username and password and token) or not (username or password or token):
+            raise ValueError('Pass in either a username/password pair or token')
+
+        if (username and not password) or (password and not username):
+            raise ValueError('Username/passwod supplied but not the other')
+
+        self.username = username
+        self.password = password
+        self.token = token
+
+
+def get_repo(repo_name, credentials=None):
+    """Retrieves a Repository by its fully qualified name. If credentials are passed
+    they will be used. The repo can be manipulated with the PyGithub API."""
+    if not credentials:
+        return Github().get_repo(repo_name)
+
+    if credentials.token:
+        return Github(credentials.token).get_repo(repo_name)
+
+    return Github(credentials.username, credentials.password).get_repo(repo_name)
+
+
+def get_github_file(repo_name, filename):
+    """Fetch and decode the file from master. Right now this method only supports public repos
+    and the repo name must be fully qualified e.g. ocf/etc.
+    Note that GitHub's API only supports files up to 1MB in size."""
+    return Github().get_repo(repo_name).get_contents(filename).decoded_content.decode('utf-8')
+
+
+def modify_and_branch(repo, base_branch, new_branch_name, commit_message, filename, file_content):
+    """Create a new branch from base_branch, makes changes to a file, and
+    commits it to the new branch."""
+
+    base_sha = repo.get_git_ref('heads/{}'.format(base_branch)).object.sha
+    base_tree = repo.get_git_tree(base_sha)
+    element = InputGitTreeElement(filename, '100644', 'blob', file_content)
+    tree = repo.create_git_tree([element], base_tree)
+
+    parent = repo.get_git_commit(base_sha)
+    commit = repo.create_git_commit(commit_message, tree, [parent])
+
+    repo.create_git_ref('refs/heads/{}'.format(new_branch_name), commit.sha)

--- a/ocflib/infra/github.py
+++ b/ocflib/infra/github.py
@@ -1,53 +1,62 @@
 from github import Github
 from github import InputGitTreeElement
 
-OCF_GITHUB_ORG = 'ocf'
-
 
 class GithubCredentials():
     """Basic class to store Github credentials and verify input"""
 
     def __init__(self, username=None, password=None, token=None):
-        if (username and password and token) or not (username or password or token):
-            raise ValueError('Pass in either a username/password pair or token')
+        if not (username or password or token):
+            raise ValueError('No credentials supplied')
+
+        if (username and password and token):
+            raise ValueError('Can\'t pass in both username/password and token')
 
         if (username and not password) or (password and not username):
-            raise ValueError('Username/passwod supplied but not the other')
+            raise ValueError('Username/password supplied but not the other')
 
         self.username = username
         self.password = password
         self.token = token
 
 
-def get_repo(repo_name, credentials=None):
-    """Retrieves a Repository by its fully qualified name. If credentials are passed
-    they will be used. The repo can be manipulated with the PyGithub API."""
-    if not credentials:
-        return Github().get_repo(repo_name)
+class GitRepo():
+    """
+    Extension of PyGithub with a couple of other helper methods.
+    """
 
-    if credentials.token:
-        return Github(credentials.token).get_repo(repo_name)
+    def __init__(self, repo_name, credentials=None):
+        """Retrieves a Repository by its fully qualified name. If credentials are passed
+        they will be used."""
+        if not credentials:
+            self._github = Github().get_repo(repo_name)
+        elif credentials.token:
+            self._github = Github(credentials.token).get_repo(repo_name)
+        else:
+            self._github = Github(credentials.username, credentials.password).get_repo(repo_name)
 
-    return Github(credentials.username, credentials.password).get_repo(repo_name)
+    @property
+    def github(self):
+        """
+        Direct access to the underlying PyGithub object.
+        """
+        return self._github
 
+    def get_file(self, filename):
+        """Fetch and decode the file from the master branch.
+        Note that GitHub's API only supports files up to 1MB in size."""
+        return self._github.get_contents(filename).decoded_content.decode('utf-8')
 
-def get_github_file(repo_name, filename):
-    """Fetch and decode the file from master. Right now this method only supports public repos
-    and the repo name must be fully qualified e.g. ocf/etc.
-    Note that GitHub's API only supports files up to 1MB in size."""
-    return Github().get_repo(repo_name).get_contents(filename).decoded_content.decode('utf-8')
+    def modify_and_branch(self, base_branch, new_branch_name, commit_message, filename, file_content):
+        """Create a new branch from base_branch, makes changes to a file, and
+        commits it to the new branch."""
 
+        base_sha = self._github.get_git_ref('heads/{}'.format(base_branch)).object.sha
+        base_tree = self._github.get_git_tree(base_sha)
+        element = InputGitTreeElement(filename, '100644', 'blob', file_content)
+        tree = self._github.create_git_tree([element], base_tree)
 
-def modify_and_branch(repo, base_branch, new_branch_name, commit_message, filename, file_content):
-    """Create a new branch from base_branch, makes changes to a file, and
-    commits it to the new branch."""
+        parent = self._github.get_git_commit(base_sha)
+        commit = self._github.create_git_commit(commit_message, tree, [parent])
 
-    base_sha = repo.get_git_ref('heads/{}'.format(base_branch)).object.sha
-    base_tree = repo.get_git_tree(base_sha)
-    element = InputGitTreeElement(filename, '100644', 'blob', file_content)
-    tree = repo.create_git_tree([element], base_tree)
-
-    parent = repo.get_git_commit(base_sha)
-    commit = repo.create_git_commit(commit_message, tree, [parent])
-
-    repo.create_git_ref('refs/heads/{}'.format(new_branch_name), commit.sha)
+        self._github.create_git_ref('refs/heads/{}'.format(new_branch_name), commit.sha)

--- a/ocflib/infra/rt.py
+++ b/ocflib/infra/rt.py
@@ -81,3 +81,14 @@ def rt_connection(user, password):
     assert resp.status_code == 200, resp.status_code
     assert '200 Ok' in resp.text
     return s
+
+
+class RtCredentials(namedtuple('RtCredentials', [
+    'username',
+    'password',
+])):
+    """Credentials for programmatically accessing RT.
+
+    :param username: str
+    :param password: str
+    """

--- a/ocflib/vhost/web.py
+++ b/ocflib/vhost/web.py
@@ -1,15 +1,104 @@
 import re
+import uuid
+from collections import namedtuple
+from datetime import date
+from textwrap import dedent
 
 from ocflib.account.search import user_attrs
 from ocflib.account.search import user_attrs_ucb
+from ocflib.infra.github import get_github_file
+from ocflib.infra.github import get_repo
+from ocflib.infra.github import modify_and_branch
+from ocflib.infra.rt import rt_connection
+from ocflib.infra.rt import RtTicket
 
 VHOST_DB_PATH = '/etc/ocf/vhost.conf'
+GITHUB_VHOST_REPO = 'ocf/etc'
+GITHUB_VHOST_WEB_PATH = 'configs/vhost.conf'
 
 
-def get_vhost_db():
-    """Returns lines from the vhost config file."""
-    with open(VHOST_DB_PATH) as f:
-        return f.read().splitlines()
+def get_vhost_db(remote=False):
+    """Returns lines from the vhost config file. If remote is True, fetches it
+    from GitHub."""
+    if remote:
+        vhosts = get_github_file(GITHUB_VHOST_REPO, GITHUB_VHOST_WEB_PATH)
+        return vhosts.splitlines()
+    else:
+        with open(VHOST_DB_PATH) as f:
+            return f.read().splitlines()
+
+
+def pr_new_vhost(credentials, username, aliases=None, docroot=None, flags=None, rt_ticket=None):
+    'Creates a GitHub pull request on the vhosts file to add a new vhost'
+    if not aliases:
+        aliases = '-'
+    else:
+        aliases = ','.join(aliases)
+
+    if not docroot:
+        docroot = '-'
+
+    if not flags:
+        flags = '-'
+
+    repo = get_repo(GITHUB_VHOST_REPO, credentials=credentials)
+    vhosts_lines = get_vhost_db(remote=True)
+
+    # skip the initial comment block
+    idx = 0
+    while idx < len(vhosts_lines):
+        if not vhosts_lines[idx].startswith('#'):
+            break
+        idx += 1
+
+    vhosts_lines.insert(idx, dedent("""
+        # added {date} web rt#{rt_ticket}
+        {username} {aliases} {docroot} {flags}""").format(
+        date=date.today(),
+        rt_ticket=rt_ticket,
+        username=username,
+        aliases=aliases,
+        docroot=docroot,
+        flags=flags,
+
+    ))
+
+    new_vhosts_file = '\n'.join(vhosts_lines) + '\n'  # newline at eof
+    new_branch_name = uuid.uuid4().hex
+
+    modify_and_branch(repo, 'master', new_branch_name,
+                      'rt#{rt_ticket}: Add vhost for {username}'.format(
+                          rt_ticket=rt_ticket,
+                          username=username,
+                      ), GITHUB_VHOST_WEB_PATH, new_vhosts_file)
+
+    pull_body = dedent("""
+        Submitted from ocflib on {date}
+
+        Username: {username}
+        Aliases: {aliases}
+        Document root: {docroot}
+        Flags: {flags}
+
+        Associated RT Ticket: {rt_ticket}
+        """).format(
+        date=date.today(),
+        rt_ticket=rt_ticket,
+        username=username,
+        aliases=aliases,
+        docroot=docroot,
+        flags=flags,
+    )
+
+    repo.create_pull(
+        title='rt#{rt_ticket}: Add vhost for {username}'.format(
+            rt_ticket=rt_ticket,
+            username=username,
+        ),
+        body=pull_body,
+        base='master',
+        head=new_branch_name,
+    )
 
 
 def get_vhosts():
@@ -84,3 +173,66 @@ def eligible_for_vhost(user):
             return True
 
     return False
+
+
+def get_tasks(celery_app, credentials=None):
+    """Return Celery tasks instantiated against the provided instance."""
+
+    @celery_app.task
+    def create_new_vhost(request):
+        try:
+            conn = rt_connection(credentials['rt'].username, credentials['rt'].password)
+            ticket = RtTicket.create(
+                conn,
+                'hostmaster',
+                request.requestor,
+                request.subject,
+                request.message,
+            )
+
+            pr_new_vhost(
+                credentials['github'],
+                request.username,
+                request.aliases,
+                request.docroot,
+                request.flags,
+                ticket.number,
+            )
+            return True
+        except Exception:
+            # TODO: Report errors via ocflib
+            return False
+
+    return _VirtualHostTasks(
+        create_new_vhost=create_new_vhost,
+    )
+
+
+_VirtualHostTasks = namedtuple('VirtualHostTasks', [
+    'create_new_vhost',
+])
+
+
+class NewVirtualHostRequest(namedtuple('NewVirtualHostRequest', [
+    'username',
+    'requestor',
+    'subdomain',
+    'aliases',
+    'docroot',
+    'flags',
+    'rt_ticket',
+    'subject',
+    'message',
+])):
+    """Request for account creation.
+
+    :param username: str
+    :param requestor: str
+    :param subdomain: str
+    :param aliases: str or None
+    :param docroot: str or None
+    :param flags: str or None
+    :param rt_ticket: str or None
+    :param subject: str or None
+    :param message: str or None
+    """

--- a/ocflib/vhost/web.py
+++ b/ocflib/vhost/web.py
@@ -85,7 +85,7 @@ def pr_new_vhost(credentials, username, aliases=None, docroot=None, flags='', rt
         Document root: {docroot}
         Flags: {flags}
 
-        Associated RT Ticket: {rt_ticket}
+        Associated RT Ticket: rt#{rt_ticket}
         https://ocf.io/rt/{rt_ticket}
         """).format(
         date=date.today(),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ freezegun
 mock
 pre-commit
 pyfakefs
-pygithub
 pytest
 pytest-cov
 pytest-xdist

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 attrs
 coveralls
 freezegun
-ipdb
 mock
 pre-commit
 pyfakefs
+pygithub
 pytest
 pytest-cov
 pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'pexpect',
         'pycryptodome',
         'pygithub',
-        'pymysql',
+        'pymysql<0.10.0',
         'pysnmp',
         'pyyaml',
         'redis',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'ldap3',
         'pexpect',
         'pycryptodome',
+        'pygithub',
         'pymysql',
         'pysnmp',
         'pyyaml',

--- a/tests/account/submission_test.py
+++ b/tests/account/submission_test.py
@@ -15,6 +15,7 @@ from ocflib.account.submission import username_pending
 from tests.account.creation_test import fake_credentials  # noqa
 from tests.account.creation_test import fake_new_account_request  # noqa
 from tests.account.creation_test import mock_rsa_key  # noqa
+from tests.fixtures_test import celery_app  # noqa
 
 
 @pytest.fixture
@@ -60,36 +61,6 @@ class TestUserHasRequestPending:
         session.add(StoredNewAccountRequest.from_request(fake_new_account_request, 'reason'))
         session.commit()
         assert not user_has_request_pending(session, fake_new_account_request)
-
-
-@pytest.fixture
-def celery_app():
-    sent_messages = []
-
-    def mock_celery_task(f):
-        def update_state(**kwargs):
-            pass
-
-        # wrap everything in Mock so we can track calls
-        return mock.Mock(
-            side_effect=f,
-            delay=mock.Mock(),
-            update_state=mock.Mock(side_effect=update_state),
-        )
-
-    @contextmanager
-    def dispatcher():
-        def send(**kwargs):
-            sent_messages.append(kwargs)
-        yield mock.Mock(send=send)
-
-    return mock.Mock(
-        task=mock_celery_task,
-        _sent_messages=sent_messages,
-        **{
-            'events.default_dispatcher': dispatcher,
-        }
-    )
 
 
 @pytest.yield_fixture

--- a/tests/fixtures_test.py
+++ b/tests/fixtures_test.py
@@ -1,0 +1,36 @@
+from contextlib import contextmanager
+
+import mock
+import pytest
+
+# Shared testing components
+
+
+@pytest.fixture
+def celery_app():
+    sent_messages = []
+
+    def mock_celery_task(f):
+        def update_state(**kwargs):
+            pass
+
+        # wrap everything in Mock so we can track calls
+        return mock.Mock(
+            side_effect=f,
+            delay=mock.Mock(),
+            update_state=mock.Mock(side_effect=update_state),
+        )
+
+    @contextmanager
+    def dispatcher():
+        def send(**kwargs):
+            sent_messages.append(kwargs)
+        yield mock.Mock(send=send)
+
+    return mock.Mock(
+        task=mock_celery_task,
+        _sent_messages=sent_messages,
+        **{
+            'events.default_dispatcher': dispatcher,
+        }
+    )

--- a/tests/infra/github_test.py
+++ b/tests/infra/github_test.py
@@ -1,10 +1,8 @@
 import mock
 
-from ocflib.infra.github import get_github_file
-from ocflib.infra.github import get_repo
 from ocflib.infra.github import GithubCredentials
-from ocflib.infra.github import modify_and_branch
-from ocflib.infra.github import OCF_GITHUB_ORG
+from ocflib.infra.github import GitRepo
+
 
 TEST_REPO_NAME = 'ocftest'
 
@@ -14,7 +12,7 @@ class TestGithub:
     @mock.patch('ocflib.infra.github.Github')
     def test_get_repo_no_credentials(self, github_mock):
         gh = github_mock.return_value
-        get_repo(TEST_REPO_NAME)
+        GitRepo(TEST_REPO_NAME)
         assert github_mock.call_count == 1
         gh.get_repo.assert_called_once_with(TEST_REPO_NAME)
 
@@ -24,7 +22,7 @@ class TestGithub:
         creds = GithubCredentials(
             username='testusername', password='testpassword'
         )
-        get_repo(TEST_REPO_NAME, credentials=creds)
+        GitRepo(TEST_REPO_NAME, credentials=creds)
         assert github_mock.call_count == 1
         github_mock.assert_called_once_with('testusername', 'testpassword')
         gh.get_repo.assert_called_once_with(TEST_REPO_NAME)
@@ -33,25 +31,25 @@ class TestGithub:
     def test_get_repo_with_token(self, github_mock):
         gh = github_mock.return_value
         creds = GithubCredentials(
-            token='testtoken'
+            token='testtoken',
         )
-        get_repo(TEST_REPO_NAME, credentials=creds)
+        GitRepo(TEST_REPO_NAME, credentials=creds)
         assert github_mock.call_count == 1
         github_mock.assert_called_once_with('testtoken')
         gh.get_repo.assert_called_once_with(TEST_REPO_NAME)
 
     def test_get_ocf_file(self):
-        assert get_github_file(OCF_GITHUB_ORG + '/ocflib', 'README.md')
+        assert GitRepo('ocf/ocflib').get_file('README.md')
 
     @mock.patch('ocflib.infra.github.Github')
     @mock.patch('ocflib.infra.github.InputGitTreeElement')
     def test_modify_and_branch(self, github_mock, inputtreeelem_mock):
-        repo = get_repo('ocf')
-        modify_and_branch(repo, 'master', 'new_branch', 'testcommit', 'testfilename', 'testcontent')
+        r = GitRepo('ocf')
+        r.modify_and_branch('master', 'new_branch', 'testcommit', 'testfilename', 'testcontent')
 
         # new ref must be created
         assert github_mock.call_count == 1
-        assert repo.create_git_ref.call_args[0][0] == 'refs/heads/new_branch'
+        assert r.github.create_git_ref.call_args[0][0] == 'refs/heads/new_branch'
 
         # at some point the new tree element must be created
         assert inputtreeelem_mock.call_count == 1

--- a/tests/infra/github_test.py
+++ b/tests/infra/github_test.py
@@ -1,0 +1,57 @@
+import mock
+
+from ocflib.infra.github import get_github_file
+from ocflib.infra.github import get_repo
+from ocflib.infra.github import GithubCredentials
+from ocflib.infra.github import modify_and_branch
+from ocflib.infra.github import OCF_GITHUB_ORG
+
+TEST_REPO_NAME = 'ocftest'
+
+
+class TestGithub:
+
+    @mock.patch('ocflib.infra.github.Github')
+    def test_get_repo_no_credentials(self, github_mock):
+        gh = github_mock.return_value
+        get_repo(TEST_REPO_NAME)
+        assert github_mock.call_count == 1
+        gh.get_repo.assert_called_once_with(TEST_REPO_NAME)
+
+    @mock.patch('ocflib.infra.github.Github')
+    def test_get_repo_with_username_and_password(self, github_mock):
+        gh = github_mock.return_value
+        creds = GithubCredentials(
+            username='testusername', password='testpassword'
+        )
+        get_repo(TEST_REPO_NAME, credentials=creds)
+        assert github_mock.call_count == 1
+        github_mock.assert_called_once_with('testusername', 'testpassword')
+        gh.get_repo.assert_called_once_with(TEST_REPO_NAME)
+
+    @mock.patch('ocflib.infra.github.Github')
+    def test_get_repo_with_token(self, github_mock):
+        gh = github_mock.return_value
+        creds = GithubCredentials(
+            token='testtoken'
+        )
+        get_repo(TEST_REPO_NAME, credentials=creds)
+        assert github_mock.call_count == 1
+        github_mock.assert_called_once_with('testtoken')
+        gh.get_repo.assert_called_once_with(TEST_REPO_NAME)
+
+    def test_get_ocf_file(self):
+        assert get_github_file(OCF_GITHUB_ORG + '/ocflib', 'README.md')
+
+    @mock.patch('ocflib.infra.github.Github')
+    @mock.patch('ocflib.infra.github.InputGitTreeElement')
+    def test_modify_and_branch(self, github_mock, inputtreeelem_mock):
+        repo = get_repo('ocf')
+        modify_and_branch(repo, 'master', 'new_branch', 'testcommit', 'testfilename', 'testcontent')
+
+        # new ref must be created
+        assert github_mock.call_count == 1
+        assert repo.create_git_ref.call_args[0][0] == 'refs/heads/new_branch'
+
+        # at some point the new tree element must be created
+        assert inputtreeelem_mock.call_count == 1

--- a/tests/vhost/web_test.py
+++ b/tests/vhost/web_test.py
@@ -1,11 +1,15 @@
 import mock
 import pytest
 
+from ocflib.infra.github import GithubCredentials
+from ocflib.infra.rt import RtCredentials
 from ocflib.vhost.web import eligible_for_vhost
+from ocflib.vhost.web import get_tasks
 from ocflib.vhost.web import get_vhost_db
 from ocflib.vhost.web import get_vhosts
 from ocflib.vhost.web import has_vhost
-
+from ocflib.vhost.web import NewVirtualHostRequest
+from tests.fixtures_test import celery_app  # noqa
 
 VHOSTS_EXAMPLE = """
 # added 2017-09-16 kpengboy
@@ -80,3 +84,63 @@ class TestVirtualHosts:
     ])
     def test_eligible_for_vhost(self, user, should_be_eligible):
         assert eligible_for_vhost(user) == should_be_eligible
+
+
+@pytest.yield_fixture
+def fake_credentials():
+    yield {
+        'rt': RtCredentials(username='ocf', password='password'),
+        'github': GithubCredentials(token='ocf')
+    }
+
+
+@pytest.yield_fixture
+def tasks(celery_app, fake_credentials):
+    yield get_tasks(celery_app, fake_credentials)
+
+
+@pytest.yield_fixture
+def fake_new_vhost_request():
+    yield NewVirtualHostRequest(
+        'ocf',
+        'ocf@ocf.berkeley.edu',
+        'ocf.berkeley.edu',
+        None,
+        None,
+        None,
+        '0',
+        'vhost request for ocf',
+        'body',
+    )
+
+
+@pytest.yield_fixture
+def mock_rt_connection():
+    with mock.patch('ocflib.vhost.web.rt_connection') as m:
+        yield m
+
+
+@pytest.yield_fixture
+def mock_rtticket_create():
+    with mock.patch('ocflib.vhost.web.RtTicket.create') as m:
+        yield m
+
+
+@pytest.yield_fixture
+def mock_github():
+    with mock.patch('ocflib.infra.github.Github') as m:
+        yield m
+
+
+def test_create_new_vhost_successful(
+        celery_app,
+        mock_rt_connection,
+        mock_rtticket_create,
+        fake_new_vhost_request,
+        mock_github,
+        tasks):
+    resp = tasks.create_new_vhost(fake_new_vhost_request)
+    assert resp
+    assert mock_rt_connection.called
+    assert mock_rtticket_create.called
+    assert mock_github.called

--- a/tests/vhost/web_test.py
+++ b/tests/vhost/web_test.py
@@ -9,8 +9,8 @@ from ocflib.vhost.web import get_vhost_db
 from ocflib.vhost.web import get_vhosts
 from ocflib.vhost.web import has_vhost
 from ocflib.vhost.web import NewVirtualHostRequest
+from ocflib.vhost.web import pr_new_vhost
 from tests.fixtures_test import celery_app  # noqa
-# from ocflib.vhost.web import pr_new_vhost
 
 VHOSTS_EXAMPLE = """
 # added 2017-09-16 kpengboy
@@ -178,14 +178,15 @@ def test_create_new_vhost_successful(
         3,
     )
 
-# def test_pr_new_vhost(mock_gitrepo, fake_credentials):
 
-#     mock_vhost = mock.patch("ocflib.vhost.web.get_vhost_db", return_value="")
+def test_pr_new_vhost(mock_gitrepo, fake_credentials):
 
-#     pr_new_vhost(
-#         fake_credentials,
-#         "ocf",
-#         aliases="ocfweb",
-#         docroot="/web",
-#         rt_ticket="1234",
-#     )
+    mock.patch('ocflib.vhost.web.get_vhost_db', return_value='')
+
+    pr_new_vhost(
+        fake_credentials,
+        'ocf',
+        aliases='ocfweb',
+        docroot='/web',
+        rt_ticket='1234',
+    )

--- a/tests/vhost/web_test.py
+++ b/tests/vhost/web_test.py
@@ -208,9 +208,12 @@ def test_pr_new_vhost(mock_uuid, mock_vhost_db, mock_gitrepo, fake_credentials):
 
     expected_end_result = dedent("""
     # added {date} web rt#1234
-    ocf ocfweb /web
+    ocf ocfweb /web{space}
 
-    """.format(date=date.today()))
+    """.format(
+        date=date.today(),
+        space=' ')
+    )
 
     expected_branch_name = 'rt#1234-{}'.format(str(mock_uuid.uuid4.return_value.hex))
 
@@ -228,12 +231,13 @@ def test_pr_new_vhost(mock_uuid, mock_vhost_db, mock_gitrepo, fake_credentials):
         Username: ocf
         Aliases: ocfweb
         Document root: /web
-        Flags:
+        Flags:{space}
 
         Associated RT Ticket: rt#1234
         https://ocf.io/rt/1234
         """).format(
         date=date.today(),
+        space=' ',
     )
 
     mock_gitrepo.return_value.github.create_pull.assert_called_with(


### PR DESCRIPTION
Staff (me recently) spend a lot of time typing usernames and hyphens into text files using the github web interface. I think this part is worth automating out, and the methods can also be used for future interaction with GitHub and RT.

So far I've manually tested in queue `test2` and the repo `ja5087/etc`, and it works fairly well.


