### PR TITLE
Restrict pymysql version to below 0.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'ldap3',
         'pexpect',
         'pycryptodome',
-        'pymysql',
+        'pymysql<0.10.0',
         'pysnmp',
         'pyyaml',
         'redis',


### PR DESCRIPTION
this is breaking tests on master due to breaking API changes

imagine releasing a new library version after 2 years and breaking things and no changelog