### PR TITLE
setup.py: temporarily downgrade requests to satisfy pygithub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'pysnmp',
         'pyyaml',
         'redis',
-        'requests',
+        'requests<2.25',  # temporarily downgraded due to pygithub incompat
         'sqlalchemy',
     ),
     classifiers=[


### PR DESCRIPTION
Fixes the current error when running tests:

```
pygithub 1.54 has requirement requests<2.25,>=2.14.0, but you'll have requests 2.25.0 which is incompatible.
```