### PR TITLE
Add membership to reserved usernames

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -24,7 +24,7 @@ from ocflib.misc.validators import valid_email
 from ocflib.printing.quota import SEMESTERLY_QUOTA
 
 
-_KNOWN_UID = 74209
+_KNOWN_UID = 78418
 BAD_WORDS = frozenset((
     'anal', 'anus', 'arse', 'ass', 'bastard', 'bitch', 'biatch', 'bloody', 'blowjob', 'bollock',
     'bollok', 'boner', 'chink', 'clit', 'cock', 'coon', 'cunt', 'damn', 'dick', 'dildo', 'douche',

--- a/ocflib/account/validators.py
+++ b/ocflib/account/validators.py
@@ -359,7 +359,7 @@ def validate_password(username, password, strength_check=True):
     encountered. Optionally checks password strength."""
 
     if strength_check:
-        if len(password) < 8:
+        if len(password) < 12:
             raise ValueError('Password must be at least 8 characters.')
 
         s = difflib.SequenceMatcher()

--- a/ocflib/account/validators.py
+++ b/ocflib/account/validators.py
@@ -360,7 +360,7 @@ def validate_password(username, password, strength_check=True):
 
     if strength_check:
         if len(password) < 12:
-            raise ValueError('Password must be at least 8 characters.')
+            raise ValueError('Password must be at least 12 characters.')
 
         s = difflib.SequenceMatcher()
         s.set_seqs(password, username)

--- a/ocflib/account/validators.py
+++ b/ocflib/account/validators.py
@@ -127,6 +127,7 @@ RESERVED_USERNAMES = frozenset((
     'marketing',
     'mastodon',
     'matrix',
+    'membership',
     'memcache',
     'mesos',
     'messagebus',

--- a/ocflib/lab/hours.py
+++ b/ocflib/lab/hours.py
@@ -81,6 +81,9 @@ def _parse_hours_list(time_ranges):
     """
     hours = []
 
+    if time_ranges is None:
+        return hours
+
     for hour in time_ranges:
         if not isinstance(hour, Hour):
             hour = Hour(hour[0], hour[1])

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -70,7 +70,7 @@ def fake_new_account_request(mock_rsa_key):
         calnet_uid=123456,
         callink_oid=None,
         email='some.user@ocf.berkeley.edu',
-        encrypted_password=encrypt_password('hunter2000', RSA.importKey(WEAK_KEY)),
+        encrypted_password=encrypt_password('hunter20000000', RSA.importKey(WEAK_KEY)),
         handle_warnings=NewAccountRequest.WARNINGS_WARN,
     )
 

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -529,7 +529,7 @@ class TestCreateAccount:
                 fake_new_account_request.user_name,
                 fake_credentials.kerberos_keytab,
                 fake_credentials.kerberos_principal,
-                password='hunter2000',
+                password='hunter20000000',
             )
             ldap.assert_called_once_with(
                 'uid=someuser,ou=People,dc=OCF,dc=Berkeley,dc=EDU',

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -376,7 +376,7 @@ class TestValidatePassword:
     @pytest.mark.parametrize('password', [
         'correct horse battery staple',
         'pogjpaioshfoasdfnlka;sdfi;sagj',
-        'p@ssw0rd',
+        'ixChytH2GJYBcTZd',
     ])
     def test_valid_password(self, password):
         validate_password('ckuehl', password)
@@ -384,6 +384,7 @@ class TestValidatePassword:
     @pytest.mark.parametrize('password', [
         '',
         'simple',
+        'p@ssw0rd',
         'correct horse\nbattery staple',
         'correct horse battery staple é',
     ])

--- a/tests/account/creation_test.py
+++ b/tests/account/creation_test.py
@@ -140,7 +140,7 @@ class TestFirstAvailableUID:
             )
             num_uids = len(c.response)
 
-        if num_uids > 2500:
+        if num_uids > 3500:
             raise AssertionError((
                 'Found {} accounts with UID >= {}, you should bump the constant for speed.'
             ).format(num_uids, _KNOWN_UID))

--- a/tests/account/utils_test.py
+++ b/tests/account/utils_test.py
@@ -150,7 +150,7 @@ def test_list_group():
     ocfstaff = list_group('ocfstaff')
     assert 'gstaff' in ocfstaff
     assert 'guser' not in ocfstaff
-    assert 5 <= len(ocfstaff) <= 250
+    assert 5 <= len(ocfstaff) <= 300
 
     opstaff = list_group('opstaff')
     assert 'testopstaff' in opstaff

--- a/tests/account/validators_test.py
+++ b/tests/account/validators_test.py
@@ -70,7 +70,7 @@ class TestValidatePassword:
         with pytest.raises(ValueError):
             validate_password('ckuehl', password)
 
-    @pytest.mark.parametrize('password', ['a strong password', '53y4kZ1hKq'])
+    @pytest.mark.parametrize('password', ['a strong password', 'oyYvIiInyCgw6VV7u'])
     def test_success(self, password):
         validate_password('ckuehl', password)
 


### PR DESCRIPTION
See ocf/puppet#1283. Adds `membership` to list of reserved usernames (used as shorturl).