### PR TITLE
Add support for null/closed hours

### DIFF
--- a/ocflib/account/creation.py
+++ b/ocflib/account/creation.py
@@ -24,7 +24,7 @@ from ocflib.misc.validators import valid_email
 from ocflib.printing.quota import SEMESTERLY_QUOTA
 
 
-_KNOWN_UID = 74209
+_KNOWN_UID = 78418
 BAD_WORDS = frozenset((
     'anal', 'anus', 'arse', 'ass', 'bastard', 'bitch', 'biatch', 'bloody', 'blowjob', 'bollock',
     'bollok', 'boner', 'chink', 'clit', 'cock', 'coon', 'cunt', 'damn', 'dick', 'dildo', 'douche',

--- a/ocflib/lab/hours.py
+++ b/ocflib/lab/hours.py
@@ -81,6 +81,9 @@ def _parse_hours_list(time_ranges):
     """
     hours = []
 
+    if time_ranges is None:
+        return hours
+
     for hour in time_ranges:
         if not isinstance(hour, Hour):
             hour = Hour(hour[0], hour[1])


### PR DESCRIPTION
Adds support for closing the lab for the entire day regularly (such as the current situation with MLK being closed on Sundays). More info: https://github.com/ocf/etc/pull/250#issuecomment-903232452

To close for a day, edit [etc/hours.yaml](https://github.com/ocf/etc/blob/master/configs/hours.yaml) to something like the following (this example would close Sunday):
```yaml
regular:
  ...
  Satuday:
    - ['11:00', '18:00']
  Sunday: null
```

The result is something that looks like the following (note the "Closed All Day" days)
![hours](https://user-images.githubusercontent.com/31583652/178137786-ee2d4e7d-f742-4494-a3a5-307c4501de36.png)

