### PR TITLE
use ldap3 from Nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,7 @@
 , attrs
 , dnspython
 , jinja2
+, ldap3
 , passlib
 , pexpect
 , pycryptodome
@@ -64,30 +65,6 @@ let
     propagatedBuildInputs = [ x690 ];
     doCheck = false;
   };
-  ldap3 = buildPythonPackage rec {
-  pname = "ldap3";
-  version = "2.9.1";
-  format = "setuptools";
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f3e7fc4718e3f09dda568b57100095e0ce58633bcabbed8667ce3f8fbaa4229f";
-  };
-  prePatch = ''
-    # patch fails to apply because of line endings
-    dos2unix ldap3/utils/asn1.py
-  '';
-  patches = [
-    # fix pyasn1 0.5.0 compatibility
-    # https://github.com/cannatag/ldap3/pull/983
-    (fetchpatch {
-      url = "https://github.com/cannatag/ldap3/commit/ca689f4893b944806f90e9d3be2a746ee3c502e4.patch";
-      hash = "sha256-A8qI0t1OV3bkKaSdhVWHFBC9MoSkWynqxpgznV+5gh8=";
-    })
-  ];
-  nativeBuildInputs = [ dos2unix ];
-  propagatedBuildInputs = [ pyasn1 ];
-  doCheck = false; # requires network
-};
 in
 
 buildPythonPackage {


### PR DESCRIPTION
Otherwise using `python3.withPackages (ps: [ ps.ldap3 ps.ocflib ])` results in
```
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  `/nix/store/c3592ilp83az3vyrcgbmxv6iiqxbz9l8-python3.14-ldap3-2.9.1/lib/python3.14/site-packages/ldap3/utils/ciDict.py' and
  `/nix/store/cml2p3mb2jnws0yk9ziwyd67m3gdq4c9-python3.14-ldap3-2.9.1/lib/python3.14/site-packages/ldap3/utils/ciDict.py'
hint: this may be caused by two different versions of the same package in buildEnv's `paths` parameter
hint: `pkgs.nix-diff` can be used to compare derivations
```